### PR TITLE
refactor: extract Windows build into reusable workflow

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -157,28 +157,7 @@ jobs:
 
   windows-build:
     if: github.actor != 'trailheadapps-bot'
-    runs-on: windows-latest
-    steps:
-      - name: "Checkout source code"
-        uses: actions/checkout@v4
-
-      - name: "Setup Node"
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: force-app/main/react-recipes/uiBundles/reactRecipes/package-lock.json
-
-      - name: "Install React app dependencies"
-        run: npm ci --prefix force-app/main/react-recipes/uiBundles/reactRecipes
-
-      - name: "Build"
-        run: npm run build
-        working-directory: force-app/main/react-recipes/uiBundles/reactRecipes
-
-      - name: "Test"
-        run: npx vitest --run
-        working-directory: force-app/main/react-recipes/uiBundles/reactRecipes
+    uses: ./.github/workflows/windows-build.yml
 
   scratch-org-test:
     runs-on: trailheadapps-Ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,28 +139,7 @@ jobs:
           exit 1
 
   windows-build:
-    runs-on: windows-latest
-    steps:
-      - name: "Checkout source code"
-        uses: actions/checkout@v4
-
-      - name: "Setup Node"
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: force-app/main/react-recipes/uiBundles/reactRecipes/package-lock.json
-
-      - name: "Install React app dependencies"
-        run: npm ci --prefix force-app/main/react-recipes/uiBundles/reactRecipes
-
-      - name: "Build"
-        run: npm run build
-        working-directory: force-app/main/react-recipes/uiBundles/reactRecipes
-
-      - name: "Test"
-        run: npx vitest --run
-        working-directory: force-app/main/react-recipes/uiBundles/reactRecipes
+    uses: ./.github/workflows/windows-build.yml
 
   scratch-org-test:
     runs-on: trailheadapps-Ubuntu

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,37 @@
+name: Windows Build
+
+on:
+  workflow_call:
+
+jobs:
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v4
+
+      - name: "Setup Node"
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: npm
+          cache-dependency-path: force-app/main/react-recipes/uiBundles/reactRecipes/package-lock.json
+
+      - name: "Restore React app node_modules cache"
+        id: cache-react-npm
+        uses: actions/cache@v4
+        with:
+          path: force-app/main/react-recipes/uiBundles/reactRecipes/node_modules
+          key: windows-react-npm-${{ hashFiles('force-app/main/react-recipes/uiBundles/reactRecipes/package-lock.json') }}
+
+      - name: "Install React app dependencies"
+        if: steps.cache-react-npm.outputs.cache-hit != 'true'
+        run: npm ci --prefix force-app/main/react-recipes/uiBundles/reactRecipes
+
+      - name: "Build"
+        run: npm run build
+        working-directory: force-app/main/react-recipes/uiBundles/reactRecipes
+
+      - name: "Test"
+        run: npm run test -- --run
+        working-directory: force-app/main/react-recipes/uiBundles/reactRecipes


### PR DESCRIPTION
## Summary

- Extracts the duplicated `windows-build` job from `ci.yml` and `ci-pr.yml` into a shared reusable workflow (`.github/workflows/windows-build.yml`)
- Uses `node-version-file: "package.json"` instead of hardcoding `node-version: 22`, so it stays in sync with the Volta config
- Adds `actions/cache@v4` for `node_modules` so installs are skipped on cache hits (faster CI)
- Uses `npm run test -- --run` instead of bare `npx vitest --run` to match the Linux CI job and pick up any script-level configuration

## Test plan

- [x] Verify the reusable workflow triggers correctly on both `ci.yml` (push to main) and `ci-pr.yml` (pull request)
- [x] Confirm `node-version-file` correctly reads Node 22.x from the Volta config in `package.json`
- [x] Confirm `node_modules` cache is populated on first run and used on subsequent runs
- [x] Verify build and test pass on Windows