### PR TITLE
Add CustomApplication metadata

### DIFF
--- a/force-app/main/default/applications/MultiFrameworkApp.app-meta.xml
+++ b/force-app/main/default/applications/MultiFrameworkApp.app-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+   <brand>
+       <headerColor>#0070D2</headerColor>
+       <shouldOverrideOrgTheme>false</shouldOverrideOrgTheme>
+   </brand>
+   <formFactors>Small</formFactors>
+   <formFactors>Large</formFactors>
+   <isNavAutoTempTabsDisabled>false</isNavAutoTempTabsDisabled>
+   <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>
+   <isNavTabPersistenceDisabled>false</isNavTabPersistenceDisabled>
+   <isOmniPinnedViewEnabled>false</isOmniPinnedViewEnabled>
+   <label>Multi Framework App</label>
+   <navType>Standard</navType>
+   <uiBundle>c__reactRecipes</uiBundle>
+   <uiType>Lightning</uiType>
+</CustomApplication>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
       "path": "force-app",
       "default": true,
       "package": "ReactRecipes",
-      "versionName": "Spring '26",
+      "versionName": "Summer '26",
       "versionNumber": "67.0.0.NEXT"
     }
   ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -11,5 +11,5 @@
   "name": "multiframework-recipes",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "66.0"
+  "sourceApiVersion": "67.0"
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
       "default": true,
       "package": "ReactRecipes",
       "versionName": "Spring '26",
-      "versionNumber": "66.0.0.NEXT"
+      "versionNumber": "67.0.0.NEXT"
     }
   ],
   "name": "multiframework-recipes",


### PR DESCRIPTION
### What does this PR do?
Add CustomApplication metadata for internal facing UiBundle
### What issues does this PR fix or reference?
As part of 262.8 release, UiBundle now requires CustomApplication to be considered as an internal application.

This PR includes a sample CustomApplication metadata and bumped version to be 67.0.

UiBundle can still be deployed on its own but it will not be visible and cannot be accessed once 262.8 is released on that server.

This PR should only be merged on June 13, 2026 once R2 major release completes.

#<Insert GitHub Issue>

## The PR fulfills these requirements:

- [ ] Tests for the proposed changes have been added/updated.
- [ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
