### PR TITLE
Add Custom Application metadata  

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,14 +1,11 @@
 {
   "orgName": "My Saleforce Org",
-  "edition": "developer",
+  "edition": "Developer",
   "language": "en_US",
   "features": ["EnableSetPasswordInApi"],
   "settings": {
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true
-    },
-    "UIBundleSettings": {
-      "webAppOptIn": true
     },
     "mobileSettings": {
       "enableS1EncryptedStoragePref2": false

--- a/force-app/main/default/applications/MultiFrameworkApp.app-meta.xml
+++ b/force-app/main/default/applications/MultiFrameworkApp.app-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+   <brand>
+       <headerColor>#0070D2</headerColor>
+       <shouldOverrideOrgTheme>false</shouldOverrideOrgTheme>
+   </brand>
+   <formFactors>Small</formFactors>
+   <formFactors>Large</formFactors>
+   <isNavAutoTempTabsDisabled>false</isNavAutoTempTabsDisabled>
+   <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>
+   <isNavTabPersistenceDisabled>false</isNavTabPersistenceDisabled>
+   <isOmniPinnedViewEnabled>false</isOmniPinnedViewEnabled>
+   <label>Multi Framework App</label>
+   <navType>Standard</navType>
+   <uiBundle>c__reactRecipes</uiBundle>
+   <uiType>Lightning</uiType>
+</CustomApplication>

--- a/force-app/main/default/applications/reactRecipes.app-meta.xml
+++ b/force-app/main/default/applications/reactRecipes.app-meta.xml
@@ -10,7 +10,7 @@
    <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>
    <isNavTabPersistenceDisabled>false</isNavTabPersistenceDisabled>
    <isOmniPinnedViewEnabled>false</isOmniPinnedViewEnabled>
-   <label>Multi Framework App</label>
+   <label>React Recipes</label>
    <navType>Standard</navType>
    <uiBundle>c__reactRecipes</uiBundle>
    <uiType>Lightning</uiType>

--- a/force-app/main/default/permissionsets/recipes.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/recipes.permissionset-meta.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>reactRecipes</application>
+        <visible>true</visible>
+    </applicationVisibilities>
     <fieldPermissions>
         <editable>true</editable>
         <field>Account.AccountNumber</field>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
       "path": "force-app",
       "default": true,
       "package": "ReactRecipes",
-      "versionName": "Spring '26",
+      "versionName": "Summer '26",
       "versionNumber": "67.0.0.NEXT"
     }
   ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -11,5 +11,5 @@
   "name": "multiframework-recipes",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "66.0"
+  "sourceApiVersion": "67.0"
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,7 +5,7 @@
       "default": true,
       "package": "ReactRecipes",
       "versionName": "Spring '26",
-      "versionNumber": "66.0.0.NEXT"
+      "versionNumber": "67.0.0.NEXT"
     }
   ],
   "name": "multiframework-recipes",


### PR DESCRIPTION
### What does this PR do?
- Adds CustomApplication metadata for internal facing UiBundle and includes it in perm set (see #22).
- Removes the scratch org for opting into Salesforce Multi-Framework as orgs are automatically opted-in (see #31)

### What issues does this PR fix or reference?
Multi-Framework application doesn't work otherwise. 

## The PR fulfills these requirements:

- [ ] Tests for the proposed changes have been added/updated.
- [ ] Code linting and formatting was performed.