### PR TITLE
feat(mfe): add Receive Event and Cancelable Event embedding recipes

### DIFF
--- a/force-app/main/default/lwc/mfeCancelableEvent/mfeCancelableEvent.html
+++ b/force-app/main/default/lwc/mfeCancelableEvent/mfeCancelableEvent.html
@@ -1,0 +1,37 @@
+<template>
+    <lightning-card title="MFE Cancelable Event" icon-name="custom:custom59">
+        <div class="slds-p-around_medium">
+            <p class="slds-text-body_regular slds-m-bottom_medium">
+                Click Check submit — the host dispatches a cancelable
+                <code>submit-check</code> event. The guest vetoes locally with
+                <code>preventDefault()</code> when its form is empty, then reports the
+                outcome back via a <code>submit-decision</code> event this LWC catches.
+            </p>
+
+            <lightning-button
+                label="Check submit"
+                variant="brand"
+                onclick={handleCheck}
+                class="slds-m-bottom_medium"
+            ></lightning-button>
+
+            <template lwc:if={lastDecision}>
+                <div class="slds-box slds-theme_shade slds-m-bottom_medium">
+                    <p class="slds-text-title_caps">Guest decision</p>
+                    <p><strong>result:</strong> <code>{lastDecision}</code></p>
+                    <p class="slds-text-body_small"><strong>checked:</strong> {lastCheckedAt}</p>
+                </div>
+            </template>
+
+            <div class="shell-container" style="height: 400px">
+                <lightning-ui-embedding
+                    lwc:ref="embedding"
+                    sandbox="allow-forms allow-modals"
+                    shell-title="MFE Cancelable Event"
+                    debug={debug}
+                    src={computedSrc}
+                ></lightning-ui-embedding>
+            </div>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/mfeCancelableEvent/mfeCancelableEvent.js
+++ b/force-app/main/default/lwc/mfeCancelableEvent/mfeCancelableEvent.js
@@ -1,0 +1,51 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class MfeCancelableEvent extends LightningElement {
+    @api baseUrl = 'http://localhost:5173';
+    debug = false;
+
+    @track lastDecision = '';
+    @track lastCheckedAt = '';
+
+    _handler;
+
+    get computedSrc() {
+        const url = new URL(this.baseUrl);
+        url.pathname = '/embedding/cancelable-event';
+        return url.toString();
+    }
+
+    renderedCallback() {
+        if (this._handler) return;
+        // The guest replies with `submit-decision` (contains no hyphen issue for
+        // imperative listeners). Register on the embedding element — the event
+        // bubbles + composes out of <lightning-ui-embedding>.
+        const embedding = this.refs?.embedding;
+        if (!embedding) return;
+        this._handler = (evt) => this.handleDecision(evt);
+        embedding.addEventListener('submit-decision', this._handler);
+    }
+
+    disconnectedCallback() {
+        if (this._handler) {
+            this.refs?.embedding?.removeEventListener('submit-decision', this._handler);
+            this._handler = undefined;
+        }
+    }
+
+    handleCheck() {
+        // Host → guest: ask the guest to approve a submit. `cancelable: true` lets
+        // the guest call preventDefault() locally, but that veto does NOT return
+        // over the wire — the guest reports its decision via `submit-decision`.
+        const embedding = this.refs?.embedding;
+        if (!embedding) return;
+        this.lastCheckedAt = new Date().toLocaleTimeString();
+        this.lastDecision = 'waiting…';
+        embedding.dispatchEvent(new CustomEvent('submit-check', { cancelable: true }));
+    }
+
+    handleDecision(evt) {
+        const allowed = Boolean(evt.detail?.allowed);
+        this.lastDecision = allowed ? 'allowed' : 'vetoed';
+    }
+}

--- a/force-app/main/default/lwc/mfeCancelableEvent/mfeCancelableEvent.js-meta.xml
+++ b/force-app/main/default/lwc/mfeCancelableEvent/mfeCancelableEvent.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/mfeReceiveEvent/mfeReceiveEvent.html
+++ b/force-app/main/default/lwc/mfeReceiveEvent/mfeReceiveEvent.html
@@ -1,0 +1,39 @@
+<template>
+    <lightning-card title="MFE Receive Event" icon-name="custom:custom59">
+        <div class="slds-p-around_medium">
+            <p class="slds-text-body_regular slds-m-bottom_medium">
+                Click Notify — the host calls
+                <code>embedding.dispatchEvent(new CustomEvent('host-notify', &#123; detail &#125;))</code>.
+                The bridge forwards it to the guest, which hears it via
+                <code>viewSDK.addEventListener('host-notify', ...)</code>.
+            </p>
+
+            <lightning-button
+                label="Notify MFE"
+                variant="brand"
+                onclick={handleNotify}
+                class="slds-m-bottom_medium"
+            ></lightning-button>
+
+            <template lwc:if={sentCount}>
+                <div class="slds-box slds-theme_shade slds-m-bottom_medium">
+                    <p class="slds-text-title_caps">Last push</p>
+                    <p><strong>sent:</strong> {lastSentAt}</p>
+                    <p class="slds-text-body_small">
+                        <strong>total sent:</strong> {sentCount}
+                    </p>
+                </div>
+            </template>
+
+            <div class="shell-container" style="height: 400px">
+                <lightning-ui-embedding
+                    lwc:ref="embedding"
+                    sandbox="allow-forms allow-modals"
+                    shell-title="MFE Receive Event"
+                    debug={debug}
+                    src={computedSrc}
+                ></lightning-ui-embedding>
+            </div>
+        </div>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/mfeReceiveEvent/mfeReceiveEvent.js
+++ b/force-app/main/default/lwc/mfeReceiveEvent/mfeReceiveEvent.js
@@ -1,0 +1,31 @@
+import { LightningElement, api, track } from 'lwc';
+
+export default class MfeReceiveEvent extends LightningElement {
+    @api baseUrl = 'http://localhost:5173';
+    debug = false;
+
+    @track sentCount = 0;
+    @track lastSentAt = '';
+
+    get computedSrc() {
+        const url = new URL(this.baseUrl);
+        url.pathname = '/embedding/receive-event';
+        return url.toString();
+    }
+
+    handleNotify() {
+        // Host → guest: dispatch a CustomEvent on <lightning-ui-embedding>. The
+        // component forwards it over the wire (ui/events/dispatch) and the guest
+        // hears it through viewSDK.addEventListener('host-notify', ...). Events
+        // are only forwarded while the guest has a listener attached.
+        const embedding = this.refs?.embedding;
+        if (!embedding) return;
+        this.sentCount += 1;
+        this.lastSentAt = new Date().toLocaleTimeString();
+        embedding.dispatchEvent(
+            new CustomEvent('host-notify', {
+                detail: { message: `Ping #${this.sentCount} from Salesforce` },
+            }),
+        );
+    }
+}

--- a/force-app/main/default/lwc/mfeReceiveEvent/mfeReceiveEvent.js-meta.xml
+++ b/force-app/main/default/lwc/mfeReceiveEvent/mfeReceiveEvent.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/mfe/recipes/CancelableEvent.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/mfe/recipes/CancelableEvent.tsx
@@ -1,0 +1,131 @@
+/**
+ * Cancelable Event
+ *
+ * Some host-pushed events ask the guest to approve an action before the host
+ * commits it — e.g. "the user is about to submit; is the form valid?". The host
+ * dispatches the event with `cancelable: true`; the guest vetoes by calling
+ * `event.preventDefault()`.
+ *
+ * Key concept — the veto is LOCAL, not a return value. `ui/events/dispatch` is
+ * fire-and-forget: calling `preventDefault()` cancels the event only inside the
+ * guest document; it does NOT travel back over the wire to the host. To tell the
+ * host the outcome, dispatch a reply event with `view.dispatchEvent()`. This
+ * recipe answers every `submit-check` with a `submit-decision` event carrying
+ * `{ allowed }`.
+ *
+ * The listener reads live form state via a ref so it never re-subscribes on
+ * keystrokes yet always sees the current value.
+ *
+ * @see ReceiveEvent — plain host → guest events with no reply
+ * @see SendEvent — guest → host events
+ */
+import { useEffect, useRef, useState } from 'react';
+import { isSfEmbeddingIframe } from '@salesforce/platform-sdk';
+import { useSdk } from '../sdk-context';
+
+// Host asks with `submit-check`; guest answers with `submit-decision`.
+const HOST_REQUEST = 'submit-check';
+const GUEST_REPLY = 'submit-decision';
+
+interface DecisionLog {
+    allowed: boolean;
+    reason: string;
+    at: string;
+}
+
+export default function CancelableEvent() {
+    const { view } = useSdk();
+    const [name, setName] = useState('');
+    const [log, setLog] = useState<DecisionLog[]>([]);
+    const connected = isSfEmbeddingIframe();
+
+    // The listener closes over this ref, so it always sees the latest name
+    // without re-subscribing on every keystroke.
+    const nameRef = useRef(name);
+    useEffect(() => {
+        nameRef.current = name;
+    }, [name]);
+
+    useEffect(() => {
+        if (!view.addEventListener) return;
+
+        const handleHostCheck = (evt: Event) => {
+            const isValid = nameRef.current.trim().length > 0;
+
+            // Veto locally — cancels the event inside this document only.
+            if (!isValid) evt.preventDefault();
+
+            // Round-trip the decision back to the host (preventDefault does not).
+            view.dispatchEvent?.(
+                new CustomEvent(GUEST_REPLY, {
+                    detail: { allowed: isValid },
+                    bubbles: true,
+                    composed: true,
+                }),
+            );
+
+            setLog(prev => [
+                {
+                    allowed: isValid,
+                    reason: isValid ? 'name present' : 'name empty — vetoed',
+                    at: new Date().toLocaleTimeString(),
+                },
+                ...prev.slice(0, 9),
+            ]);
+        };
+
+        view.addEventListener(HOST_REQUEST, handleHostCheck);
+        return () => view.removeEventListener?.(HOST_REQUEST, handleHostCheck);
+    }, [view]);
+
+    return (
+        <div className="recipe-container">
+            <h2 className="recipe-title">Cancelable Event</h2>
+            <p className="recipe-description">
+                The host asks <code>{HOST_REQUEST}</code> before committing an action. This
+                guest vetoes with <code>event.preventDefault()</code> when the form is
+                invalid, then replies with a <code>{GUEST_REPLY}</code> event carrying the
+                decision — because a fire-and-forget event's <code>preventDefault()</code>{' '}
+                does not travel back to the host.
+            </p>
+
+            {!connected && (
+                <div className="recipe-alert alert-info">
+                    Running standalone — no host is asking. Embed this app in the
+                    mfeCancelableEvent LWC to drive the check.
+                </div>
+            )}
+
+            <div className="recipe-card" style={{ marginBottom: 12 }}>
+                <label style={{ display: 'block' }}>
+                    <p className="recipe-label" style={{ marginBottom: 4 }}>
+                        Applicant name (empty = host submit will be vetoed)
+                    </p>
+                    <input
+                        className="recipe-input"
+                        value={name}
+                        onChange={e => setName(e.target.value)}
+                        placeholder="e.g. Jane Doe"
+                    />
+                </label>
+            </div>
+
+            {log.length > 0 && (
+                <div className="recipe-card">
+                    <p className="recipe-label">Decisions</p>
+                    <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12 }}>
+                        {log.map((entry, i) => (
+                            <li key={i} style={{ marginBottom: 4 }}>
+                                <span className={`status-dot ${entry.allowed ? 'dot-green' : 'dot-gray'}`} />
+                                <code>{entry.allowed ? 'allowed' : 'vetoed'}</code>
+                                <span style={{ color: '#9ca3af', marginLeft: 8 }}>
+                                    {entry.reason} · {entry.at}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/mfe/recipes/ReceiveEvent.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/mfe/recipes/ReceiveEvent.tsx
@@ -1,0 +1,95 @@
+/**
+ * Receive Event
+ *
+ * Listens for custom events pushed from the Salesforce LWC host — the mirror
+ * of Send Event. The host dispatches a CustomEvent on the
+ * <lightning-ui-embedding> element; the bridge forwards it over the wire and
+ * the SDK re-dispatches it locally, so viewSDK.addEventListener() hears it.
+ *
+ * Key concept: viewSDK is a DOM EventTarget. Register with
+ *   view.addEventListener(name, handler)
+ * and every host push of that event name fires the handler with the payload on
+ * event.detail. Always remove the listener on unmount so stale handlers don't
+ * leak — registering a listener is also what tells the host it has a subscriber
+ * (the host only forwards events while at least one listener is attached).
+ *
+ * @see SendEvent — dispatching events from the guest to the host
+ */
+import { useEffect, useState } from 'react';
+import { isSfEmbeddingIframe } from '@salesforce/platform-sdk';
+import { useSdk } from '../sdk-context';
+
+// The host pushes this event name; keep it in sync with the mfeReceiveEvent LWC.
+const HOST_EVENT = 'host-notify';
+
+interface EventLog {
+    message: string;
+    receivedAt: string;
+}
+
+export default function ReceiveEvent() {
+    const { view } = useSdk();
+    const [log, setLog] = useState<EventLog[]>([]);
+    const connected = isSfEmbeddingIframe();
+
+    useEffect(() => {
+        if (!view.addEventListener) return;
+
+        // Host → guest: every dispatch of `host-notify` from the LWC lands here.
+        const handler = (evt: Event) => {
+            const detail = ((evt as CustomEvent).detail ?? {}) as { message?: string };
+            setLog(prev => [
+                {
+                    message: typeof detail.message === 'string' ? detail.message : '(no payload)',
+                    receivedAt: new Date().toLocaleTimeString(),
+                },
+                ...prev.slice(0, 9),
+            ]);
+        };
+
+        view.addEventListener(HOST_EVENT, handler);
+        return () => view.removeEventListener?.(HOST_EVENT, handler);
+    }, [view]);
+
+    return (
+        <div className="recipe-container">
+            <h2 className="recipe-title">Receive Event</h2>
+            <p className="recipe-description">
+                Listens for <code>{HOST_EVENT}</code> events pushed from the Salesforce
+                host via <code>viewSDK.addEventListener()</code>. Click the button in the
+                LWC host — each event arrives with its payload on{' '}
+                <code>event.detail</code>.
+            </p>
+
+            {!connected && (
+                <div className="recipe-alert alert-info">
+                    Running standalone — no host is pushing events. Embed this app in the
+                    mfeReceiveEvent LWC to see live events.
+                </div>
+            )}
+
+            <div className="recipe-card">
+                <p className="recipe-label">Events received</p>
+                <p className="recipe-value">{log.length}</p>
+
+                <p className="recipe-label">History</p>
+                {log.length > 0 ? (
+                    <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12 }}>
+                        {log.map((entry, i) => (
+                            <li key={i} style={{ marginBottom: 4 }}>
+                                <code>{entry.message}</code>
+                                <span style={{ color: '#9ca3af', marginLeft: 8 }}>
+                                    {entry.receivedAt}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="recipe-value" style={{ color: '#9ca3af' }}>
+                        Waiting for host events…
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/pages/Mfe.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/pages/Mfe.tsx
@@ -39,6 +39,8 @@ import type { Framework, Hosting } from '@/recipeRegistry';
 import basicEmbedMfe from '../mfe/recipes/BasicEmbed.tsx?shiki';
 import receiveDataMfe from '../mfe/recipes/ReceiveData.tsx?shiki';
 import sendEventMfe from '../mfe/recipes/SendEvent.tsx?shiki';
+import receiveEventMfe from '../mfe/recipes/ReceiveEvent.tsx?shiki';
+import cancelableEventMfe from '../mfe/recipes/CancelableEvent.tsx?shiki';
 import autoResizeMfe from '../mfe/recipes/AutoResize.tsx?shiki';
 import themeTokensMfe from '../mfe/recipes/ThemeTokens.tsx?shiki';
 import dirtyStateMfe from '../mfe/recipes/DirtyState.tsx?shiki';
@@ -47,6 +49,8 @@ import dirtyStateMfe from '../mfe/recipes/DirtyState.tsx?shiki';
 import basicEmbedJs from '../../../../../default/lwc/mfeBasicEmbed/mfeBasicEmbed.js?shiki=js';
 import receiveDataJs from '../../../../../default/lwc/mfeReceiveData/mfeReceiveData.js?shiki=js';
 import sendEventJs from '../../../../../default/lwc/mfeSendEvent/mfeSendEvent.js?shiki=js';
+import receiveEventJs from '../../../../../default/lwc/mfeReceiveEvent/mfeReceiveEvent.js?shiki=js';
+import cancelableEventJs from '../../../../../default/lwc/mfeCancelableEvent/mfeCancelableEvent.js?shiki=js';
 import autoResizeJs from '../../../../../default/lwc/mfeAutoResize/mfeAutoResize.js?shiki=js';
 import themeTokensJs from '../../../../../default/lwc/mfeThemeTokens/mfeThemeTokens.js?shiki=js';
 import dirtyStateJs from '../../../../../default/lwc/mfeDirtyState/mfeDirtyState.js?shiki=js';
@@ -55,6 +59,8 @@ import dirtyStateJs from '../../../../../default/lwc/mfeDirtyState/mfeDirtyState
 import basicEmbedHtml from '../../../../../default/lwc/mfeBasicEmbed/mfeBasicEmbed.html?shiki=html';
 import receiveDataHtml from '../../../../../default/lwc/mfeReceiveData/mfeReceiveData.html?shiki=html';
 import sendEventHtml from '../../../../../default/lwc/mfeSendEvent/mfeSendEvent.html?shiki=html';
+import receiveEventHtml from '../../../../../default/lwc/mfeReceiveEvent/mfeReceiveEvent.html?shiki=html';
+import cancelableEventHtml from '../../../../../default/lwc/mfeCancelableEvent/mfeCancelableEvent.html?shiki=html';
 import autoResizeHtml from '../../../../../default/lwc/mfeAutoResize/mfeAutoResize.html?shiki=html';
 import themeTokensHtml from '../../../../../default/lwc/mfeThemeTokens/mfeThemeTokens.html?shiki=html';
 import dirtyStateHtml from '../../../../../default/lwc/mfeDirtyState/mfeDirtyState.html?shiki=html';
@@ -116,6 +122,34 @@ const recipes: MfeRecipe[] = [
         mfeSource: sendEventMfe,
         lwcJsSource: sendEventJs,
         lwcHtmlSource: sendEventHtml,
+      },
+    ],
+  },
+  {
+    name: 'Receive Event',
+    description:
+      'The host dispatches a CustomEvent on <lightning-ui-embedding>; the MFE hears it via viewSDK.addEventListener(name, handler) with the payload on event.detail. Mirror of Send Event.',
+    flavors: [
+      {
+        hosting: 'externally-hosted',
+        framework: 'react',
+        mfeSource: receiveEventMfe,
+        lwcJsSource: receiveEventJs,
+        lwcHtmlSource: receiveEventHtml,
+      },
+    ],
+  },
+  {
+    name: 'Cancelable Event',
+    description:
+      'The host dispatches a cancelable event; the MFE vetoes locally with event.preventDefault() and reports the decision back with viewSDK.dispatchEvent(), since a fire-and-forget event’s preventDefault() does not round-trip to the host.',
+    flavors: [
+      {
+        hosting: 'externally-hosted',
+        framework: 'react',
+        mfeSource: cancelableEventMfe,
+        lwcJsSource: cancelableEventJs,
+        lwcHtmlSource: cancelableEventHtml,
       },
     ],
   },

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipeRegistry.ts
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipeRegistry.ts
@@ -443,6 +443,22 @@ const rawRecipes: RawRecipeEntry[] = [
     category: 'Embedding',
     categoryRoute: '/embedding',
     recipeIndex: 3,
+    name: 'Receive Event',
+    description:
+      'The host dispatches a CustomEvent on <lightning-ui-embedding>; the MFE hears it via viewSDK.addEventListener(name, handler) with the payload on event.detail. Mirror of Send Event.',
+  },
+  {
+    category: 'Embedding',
+    categoryRoute: '/embedding',
+    recipeIndex: 4,
+    name: 'Cancelable Event',
+    description:
+      'The host dispatches a cancelable event; the MFE vetoes locally with event.preventDefault() and reports the decision back with viewSDK.dispatchEvent(), since a fire-and-forget event’s preventDefault() does not round-trip to the host.',
+  },
+  {
+    category: 'Embedding',
+    categoryRoute: '/embedding',
+    recipeIndex: 5,
     name: 'Auto-Resize',
     description:
       'A ResizeObserver inside the MFE tracks body height; the guest calls viewSDK.resize() to ask the host to adjust the embedding container.',
@@ -450,7 +466,7 @@ const rawRecipes: RawRecipeEntry[] = [
   {
     category: 'Embedding',
     categoryRoute: '/embedding',
-    recipeIndex: 4,
+    recipeIndex: 6,
     name: 'Theme Tokens',
     description:
       'The MFE reads the host theme via viewSDK.getTheme() and the broader environment via chatSDK.getHostContext().',
@@ -458,7 +474,7 @@ const rawRecipes: RawRecipeEntry[] = [
   {
     category: 'Embedding',
     categoryRoute: '/embedding',
-    recipeIndex: 5,
+    recipeIndex: 7,
     name: 'Dirty State',
     description:
       'The MFE calls viewSDK.markDirtyState() / clearDirtyState() to signal unsaved changes to the host surface.',

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/routes.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/routes.tsx
@@ -21,6 +21,8 @@ import GuestLayout from './mfe/GuestLayout';
 import BasicEmbed from './mfe/recipes/BasicEmbed';
 import ReceiveData from './mfe/recipes/ReceiveData';
 import SendEvent from './mfe/recipes/SendEvent';
+import ReceiveEvent from './mfe/recipes/ReceiveEvent';
+import CancelableEvent from './mfe/recipes/CancelableEvent';
 import AutoResize from './mfe/recipes/AutoResize';
 import ThemeTokens from './mfe/recipes/ThemeTokens';
 import DirtyState from './mfe/recipes/DirtyState';
@@ -124,6 +126,8 @@ export const routes: RouteObject[] = [
       { path: 'embedding/basic-embed', element: <BasicEmbed /> },
       { path: 'embedding/receive-data', element: <ReceiveData /> },
       { path: 'embedding/send-event', element: <SendEvent /> },
+      { path: 'embedding/receive-event', element: <ReceiveEvent /> },
+      { path: 'embedding/cancelable-event', element: <CancelableEvent /> },
       { path: 'embedding/auto-resize', element: <AutoResize /> },
       { path: 'embedding/theme-tokens', element: <ThemeTokens /> },
       { path: 'embedding/dirty-state', element: <DirtyState /> },


### PR DESCRIPTION
Add the ReceiveEvent and CancelableEvent guest recipes with their LWC hosts, and wire them into the registry, routes, and Embedding page.

### What does this PR do?

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

- [ ] Tests for the proposed changes have been added/updated.
- [ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
