### PR TITLE
Add Read Data recipes to Angular Recipes

### DIFF
--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/app.routes.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { AppLayoutComponent } from './components/layout/app-layout/app-layout';
 import { HomeComponent } from './pages/home/home';
 import { HelloComponent } from './pages/hello/hello';
+import { ReadDataComponent } from './pages/read-data/read-data';
 import { NotFoundComponent } from './pages/not-found/not-found';
 
 export const routes: Routes = [
@@ -17,6 +18,11 @@ export const routes: Routes = [
 				path: 'hello',
 				component: HelloComponent,
 				data: { showInNavigation: true, label: 'Hello' },
+			},
+			{
+				path: 'read-data',
+				component: ReadDataComponent,
+				data: { showInNavigation: true, label: 'Read Data' },
 			},
 			{
 				path: '**',

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/home/home.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/home/home.ts
@@ -22,5 +22,12 @@ export class HomeComponent {
 				'Start here. Covers template binding, conditional and list rendering, lifecycle, and component composition with inputs and outputs.',
 			count: getRecipeCount('/hello'),
 		},
+		{
+			to: '/read-data',
+			name: 'Read Data',
+			description:
+				'Query Salesforce records with UIAPI GraphQL: single records, lists, filtering, sorting, cursor pagination, related records, and aliased multi-object queries.',
+			count: getRecipeCount('/read-data'),
+		},
 	];
 }

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/read-data/read-data.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/read-data/read-data.html
@@ -1,0 +1,65 @@
+<app-recipe-gallery header="Read Data">
+	<ng-template
+		appRecipe="Single Record"
+		description="Queries a single Contact via UIAPI GraphQL and displays its fields. In LWC you'd reach for @wire(getRecord); here ngOnInit fetches on mount and you own loading, error, and data as signals."
+		[sources]="singleRecordSources"
+	>
+		<app-single-record />
+	</ng-template>
+
+	<ng-template
+		appRecipe="List of Records"
+		description="Queries multiple Contacts and renders each with @for. The response uses the Relay connection shape, so records arrive as edges[].node instead of a plain array."
+		[sources]="listSources"
+	>
+		<app-list-of-records />
+	</ng-template>
+
+	<ng-template
+		appRecipe="Filtered List with Variables"
+		description="Queries Contacts by name using a GraphQL variable bound to an input. A debounced handler re-runs the query with a fresh $name variable — the equivalent of a reactive @track property passed to @wire."
+		[sources]="filteredSources"
+	>
+		<app-filtered-list />
+	</ng-template>
+
+	<ng-template
+		appRecipe="Sorted Results"
+		description="Fetches Contacts with an orderBy driven by signals. Since orderBy can't be a GraphQL variable in UIAPI, the query string is rebuilt and re-run whenever the sort field or direction changes."
+		[sources]="sortedSources"
+	>
+		<app-sorted-results />
+	</ng-template>
+
+	<ng-template
+		appRecipe="Paginated List"
+		description="Fetches two Contacts at a time using Relay cursor pagination (first / after). Each Load More passes pageInfo.endCursor as $after, appending the next page to the list."
+		[sources]="paginatedSources"
+	>
+		<app-paginated-list />
+	</ng-template>
+
+	<ng-template
+		appRecipe="Related Records"
+		description="Queries Contacts with their parent Account in a single request, traversing a lookup relationship. In LWC this needs separate @wire calls; here one query covers both objects."
+		[sources]="relatedSources"
+	>
+		<app-related-records />
+	</ng-template>
+
+	<ng-template
+		appRecipe="Aliased Multi-Object Query"
+		description="Queries Accounts and Contacts in a single request using aliases. Each alias becomes its own key in the response, combining two objects into one round-trip."
+		[sources]="aliasedSources"
+	>
+		<app-aliased-multi-object-query />
+	</ng-template>
+
+	<ng-template
+		appRecipe="Imperative Refetch"
+		description="Displays a Contact list with a Refresh button that re-runs the query on demand. Unlike LWC's reactive @wire, you control exactly when data is fetched."
+		[sources]="imperativeSources"
+	>
+		<app-imperative-refetch />
+	</ng-template>
+</app-recipe-gallery>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/read-data/read-data.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/read-data/read-data.ts
@@ -1,0 +1,82 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RecipeGalleryComponent } from '../../components/app/recipe-gallery/recipe-gallery';
+import { RecipeDirective } from '../../components/app/recipe-gallery/recipe.directive';
+import type { RecipeSource } from '../../components/app/code-block/code-block';
+import { SingleRecordComponent } from '../../recipes/read-data/single-record/single-record';
+import { ListOfRecordsComponent } from '../../recipes/read-data/list-of-records/list-of-records';
+import { FilteredListComponent } from '../../recipes/read-data/filtered-list/filtered-list';
+import { SortedResultsComponent } from '../../recipes/read-data/sorted-results/sorted-results';
+import { PaginatedListComponent } from '../../recipes/read-data/paginated-list/paginated-list';
+import { RelatedRecordsComponent } from '../../recipes/read-data/related-records/related-records';
+import { AliasedMultiObjectQueryComponent } from '../../recipes/read-data/aliased-multi-object-query/aliased-multi-object-query';
+import { ImperativeRefetchComponent } from '../../recipes/read-data/imperative-refetch/imperative-refetch';
+
+// `?shiki` imports resolve to the file's highlighted source HTML (esbuild/shiki.mjs).
+import singleRecordTs from '../../recipes/read-data/single-record/single-record.ts?shiki';
+import singleRecordHtml from '../../recipes/read-data/single-record/single-record.html?shiki';
+import listTs from '../../recipes/read-data/list-of-records/list-of-records.ts?shiki';
+import listHtml from '../../recipes/read-data/list-of-records/list-of-records.html?shiki';
+import filteredTs from '../../recipes/read-data/filtered-list/filtered-list.ts?shiki';
+import filteredHtml from '../../recipes/read-data/filtered-list/filtered-list.html?shiki';
+import sortedTs from '../../recipes/read-data/sorted-results/sorted-results.ts?shiki';
+import sortedHtml from '../../recipes/read-data/sorted-results/sorted-results.html?shiki';
+import paginatedTs from '../../recipes/read-data/paginated-list/paginated-list.ts?shiki';
+import paginatedHtml from '../../recipes/read-data/paginated-list/paginated-list.html?shiki';
+import relatedTs from '../../recipes/read-data/related-records/related-records.ts?shiki';
+import relatedHtml from '../../recipes/read-data/related-records/related-records.html?shiki';
+import aliasedTs from '../../recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.ts?shiki';
+import aliasedHtml from '../../recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.html?shiki';
+import imperativeTs from '../../recipes/read-data/imperative-refetch/imperative-refetch.ts?shiki';
+import imperativeHtml from '../../recipes/read-data/imperative-refetch/imperative-refetch.html?shiki';
+
+@Component({
+	selector: 'app-read-data',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [
+		RecipeGalleryComponent,
+		RecipeDirective,
+		SingleRecordComponent,
+		ListOfRecordsComponent,
+		FilteredListComponent,
+		SortedResultsComponent,
+		PaginatedListComponent,
+		RelatedRecordsComponent,
+		AliasedMultiObjectQueryComponent,
+		ImperativeRefetchComponent,
+	],
+	templateUrl: './read-data.html',
+})
+export class ReadDataComponent {
+	protected readonly singleRecordSources: RecipeSource[] = [
+		{ label: 'single-record.ts', html: singleRecordTs },
+		{ label: 'single-record.html', html: singleRecordHtml },
+	];
+	protected readonly listSources: RecipeSource[] = [
+		{ label: 'list-of-records.ts', html: listTs },
+		{ label: 'list-of-records.html', html: listHtml },
+	];
+	protected readonly filteredSources: RecipeSource[] = [
+		{ label: 'filtered-list.ts', html: filteredTs },
+		{ label: 'filtered-list.html', html: filteredHtml },
+	];
+	protected readonly sortedSources: RecipeSource[] = [
+		{ label: 'sorted-results.ts', html: sortedTs },
+		{ label: 'sorted-results.html', html: sortedHtml },
+	];
+	protected readonly paginatedSources: RecipeSource[] = [
+		{ label: 'paginated-list.ts', html: paginatedTs },
+		{ label: 'paginated-list.html', html: paginatedHtml },
+	];
+	protected readonly relatedSources: RecipeSource[] = [
+		{ label: 'related-records.ts', html: relatedTs },
+		{ label: 'related-records.html', html: relatedHtml },
+	];
+	protected readonly aliasedSources: RecipeSource[] = [
+		{ label: 'aliased-multi-object-query.ts', html: aliasedTs },
+		{ label: 'aliased-multi-object-query.html', html: aliasedHtml },
+	];
+	protected readonly imperativeSources: RecipeSource[] = [
+		{ label: 'imperative-refetch.ts', html: imperativeTs },
+		{ label: 'imperative-refetch.html', html: imperativeHtml },
+	];
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipe-registry.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipe-registry.ts
@@ -74,6 +74,65 @@ export const recipeRegistry: RecipeEntry[] = [
 		description:
 			'Two sibling components share a selected Account by lifting state to their common parent.',
 	},
+
+	// Read Data
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 0,
+		name: 'Single Record',
+		description: 'Queries a single Contact via UIAPI GraphQL and displays its fields.',
+	},
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 1,
+		name: 'List of Records',
+		description: 'Queries multiple Contacts and renders each one from the Relay edges[].node shape.',
+	},
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 2,
+		name: 'Filtered List with Variables',
+		description: 'Queries Contacts by name using a debounced GraphQL variable bound to an input.',
+	},
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 3,
+		name: 'Sorted Results',
+		description: 'Fetches Contacts with an orderBy rebuilt from signals whenever the sort changes.',
+	},
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 4,
+		name: 'Paginated List',
+		description: 'Fetches Contacts two at a time using Relay cursor pagination (first / after).',
+	},
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 5,
+		name: 'Related Records',
+		description:
+			'Queries Contacts with their parent Account in one request, traversing a lookup relationship.',
+	},
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 6,
+		name: 'Aliased Multi-Object Query',
+		description: 'Queries Accounts and Contacts in a single request using GraphQL aliases.',
+	},
+	{
+		category: 'Read Data',
+		categoryRoute: '/read-data',
+		recipeIndex: 7,
+		name: 'Imperative Refetch',
+		description: 'Displays a Contact list with a Refresh button that re-runs the query on demand.',
+	},
 ];
 
 /** Returns the number of recipes for a given category route (e.g. "/hello"). */

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/README.md
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/README.md
@@ -7,16 +7,25 @@ Angular Recipes are self-contained examples that teach one concept at a time. Ev
 More categories are being ported from React Recipes over time. Available today:
 
 1. **Hello** -- Angular fundamentals on Salesforce: template binding, conditional rendering, lists, inputs, outputs, signals, lifecycle
+2. **Read Data** -- UIAPI GraphQL queries: single record, lists, filtering, sorting, cursor pagination, related records, aliases, imperative refetch
 
 ## Full Recipe Table
 
-| Category | Recipe                          | Description                                                                                     |
-| -------- | ------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Hello    | Hello World                     | The simplest possible Salesforce web application component.                                     |
-| Hello    | Binding to an Account Name      | Fetches an Account via UIAPI GraphQL and binds the Name field to the template.                  |
-| Hello    | Conditional Rendering           | Fetches an Account and conditionally renders different UI based on the Industry picklist value. |
-| Hello    | List Rendering (For Each)       | Fetches Accounts via GraphQL and renders them with the @for block.                              |
-| Hello    | Lifecycle (Fetch on Mount)      | Fetches a Contact in ngOnInit with cleanup to prevent stale updates.                            |
-| Hello    | Parent-to-Child (Inputs)        | The parent fetches Accounts via GraphQL and passes each one to a child component as inputs.     |
-| Hello    | Child-to-Parent (Outputs)       | A child component presents an Industry selector and emits an output to its parent.              |
-| Hello    | State Management (Shared State) | Two sibling components share a selected Account by lifting state to their common parent.        |
+| Category  | Recipe                          | Description                                                                                     |
+| --------- | ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Hello     | Hello World                     | The simplest possible Salesforce web application component.                                     |
+| Hello     | Binding to an Account Name      | Fetches an Account via UIAPI GraphQL and binds the Name field to the template.                  |
+| Hello     | Conditional Rendering           | Fetches an Account and conditionally renders different UI based on the Industry picklist value. |
+| Hello     | List Rendering (For Each)       | Fetches Accounts via GraphQL and renders them with the @for block.                              |
+| Hello     | Lifecycle (Fetch on Mount)      | Fetches a Contact in ngOnInit with cleanup to prevent stale updates.                            |
+| Hello     | Parent-to-Child (Inputs)        | The parent fetches Accounts via GraphQL and passes each one to a child component as inputs.     |
+| Hello     | Child-to-Parent (Outputs)       | A child component presents an Industry selector and emits an output to its parent.              |
+| Hello     | State Management (Shared State) | Two sibling components share a selected Account by lifting state to their common parent.        |
+| Read Data | Single Record                   | Queries a single Contact via UIAPI GraphQL and displays its fields.                             |
+| Read Data | List of Records                 | Queries multiple Contacts and renders each one from the Relay edges[].node shape.               |
+| Read Data | Filtered List with Variables    | Queries Contacts by name using a debounced GraphQL variable bound to an input.                  |
+| Read Data | Sorted Results                  | Fetches Contacts with an orderBy rebuilt from signals whenever the sort changes.                |
+| Read Data | Paginated List                  | Fetches Contacts two at a time using Relay cursor pagination (first / after).                   |
+| Read Data | Related Records                 | Queries Contacts with their parent Account in one request, traversing a lookup relationship.    |
+| Read Data | Aliased Multi-Object Query      | Queries Accounts and Contacts in a single request using GraphQL aliases.                        |
+| Read Data | Imperative Refetch              | Displays a Contact list with a Refresh button that re-runs the query on demand.                 |

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.html
@@ -1,0 +1,24 @@
+@if (loading()) {
+	<p class="text-sm">Loading…</p>
+} @else if (error(); as error) {
+	<p class="text-destructive">{{ error }}</p>
+} @else if (counts(); as counts) {
+	<div class="flex gap-4">
+		<div class="w-1/2">
+			<div
+				class="rounded-md border border-border bg-card p-4 text-center shadow-sm border-l-4 border-l-primary"
+			>
+				<p class="text-2xl font-bold tabular-nums">{{ counts.accounts }}</p>
+				<p class="text-xs text-muted-foreground mt-1">Accounts</p>
+			</div>
+		</div>
+		<div class="w-1/2">
+			<div
+				class="rounded-md border border-border bg-card p-4 text-center shadow-sm border-l-4 border-l-violet-400"
+			>
+				<p class="text-2xl font-bold tabular-nums">{{ counts.contacts }}</p>
+				<p class="text-xs text-muted-foreground mt-1">Contacts</p>
+			</div>
+		</div>
+	</div>
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.spec.ts
@@ -1,0 +1,42 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { AliasedMultiObjectQueryComponent } from './aliased-multi-object-query';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('AliasedMultiObjectQueryComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('counts the edges of each aliased connection', async () => {
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: {
+						accounts: { edges: [{ node: { Id: 'a1' } }, { node: { Id: 'a2' } }, { node: { Id: 'a3' } }] },
+						contacts: { edges: [{ node: { Id: 'c1' } }, { node: { Id: 'c2' } }] },
+					},
+				},
+			},
+		});
+		await TestBed.configureTestingModule({ imports: [AliasedMultiObjectQueryComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(AliasedMultiObjectQueryComponent);
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		const el = fixture.nativeElement as HTMLElement;
+		expect(el.textContent).toContain('3');
+		expect(el.textContent).toContain('Accounts');
+		expect(el.textContent).toContain('2');
+		expect(el.textContent).toContain('Contacts');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/aliased-multi-object-query/aliased-multi-object-query.ts
@@ -1,0 +1,84 @@
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+
+// Aliases (accounts: Account, contacts: Contact) query two objects in one
+// round-trip; each alias becomes its own key in the response.
+const QUERY = gql`
+	query MultiObjectCounts {
+		uiapi {
+			query {
+				# UIAPI has no COUNT() aggregate — edges.length is the workaround.
+				# Results are capped at first: 50, so larger sets undercount.
+				accounts: Account(first: 50) {
+					edges {
+						node {
+							Id
+						}
+					}
+				}
+				contacts: Contact(first: 50) {
+					edges {
+						node {
+							Id
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Aliased Multi-Object Query
+ *
+ * Queries Accounts and Contacts in a single request using aliases. In LWC you'd
+ * need two @wire calls or an Apex method; here aliases combine them into one
+ * round-trip, each returning its own connection.
+ *
+ * @see ImperativeRefetchComponent — re-fetching data on demand
+ */
+@Component({
+	selector: 'app-aliased-multi-object-query',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	templateUrl: './aliased-multi-object-query.html',
+})
+export class AliasedMultiObjectQueryComponent implements OnInit {
+	protected readonly counts = signal<Counts | undefined>(undefined);
+	protected readonly loading = signal(true);
+	protected readonly error = signal<string | undefined>(undefined);
+
+	async ngOnInit(): Promise<void> {
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<QueryResponse>({ query: QUERY });
+
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			const query = result?.data?.uiapi?.query;
+			this.counts.set({
+				accounts: query?.accounts?.edges?.length ?? 0,
+				contacts: query?.contacts?.edges?.length ?? 0,
+			});
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		} finally {
+			this.loading.set(false);
+		}
+	}
+}
+
+interface QueryResponse {
+	uiapi: {
+		query: {
+			accounts: { edges: { node: { Id: string } }[] };
+			contacts: { edges: { node: { Id: string } }[] };
+		};
+	};
+}
+
+interface Counts {
+	accounts: number;
+	contacts: number;
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.html
@@ -1,0 +1,50 @@
+<div>
+	<div class="space-y-1 mb-2">
+		<!-- A #box template ref reads the value without an event-target cast. -->
+		<input
+			#box
+			type="text"
+			placeholder="Search by name…"
+			class="w-full rounded-md border border-input px-3 py-2 text-sm"
+			[value]="search()"
+			(input)="onSearch(box.value)"
+		/>
+	</div>
+
+	@if (loading()) {
+		<p class="text-sm mt-2">Loading…</p>
+	} @else if (error(); as error) {
+		<p class="text-destructive mt-2">{{ error }}</p>
+	} @else if (search().trim() && contacts().length === 0) {
+		<p class="text-muted-foreground mt-2">No contacts found.</p>
+	} @else if (contacts().length > 0) {
+		<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+			<ul class="divide-y">
+				@for (contact of contacts(); track contact.id) {
+					<li class="py-2 -mx-2 px-2 rounded-md transition-colors hover:bg-accent/50">
+						<div class="flex items-center gap-3">
+							@if (contact.pictureUrl) {
+								<img
+									[src]="contact.pictureUrl"
+									[alt]="contact.name"
+									class="h-8 w-8 rounded-full object-cover"
+								/>
+							}
+							<div class="min-w-0">
+								<p class="text-sm text-foreground">{{ contact.name }}</p>
+								@if (contact.title) {
+									<p class="text-xs text-muted-foreground">{{ contact.title }}</p>
+								}
+								@if (contact.phone) {
+									<a [href]="'tel:' + contact.phone" class="text-xs text-primary hover:underline">{{
+										contact.phone
+									}}</a>
+								}
+							</div>
+						</div>
+					</li>
+				}
+			</ul>
+		</div>
+	}
+</div>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { FilteredListComponent } from './filtered-list';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('FilteredListComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('queries with a wildcard variable and renders matches after debounce', async () => {
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: {
+						Contact: {
+							edges: [
+								{ node: { Id: '1', Name: { value: 'Amy Taylor' }, Title: { value: null }, Phone: { value: null }, Picture__c: { value: null } } },
+							],
+						},
+					},
+				},
+			},
+		});
+		await TestBed.configureTestingModule({ imports: [FilteredListComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(FilteredListComponent);
+		fixture.detectChanges();
+
+		const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+		input.value = 'Amy';
+		input.dispatchEvent(new Event('input'));
+
+		// Wait past the 300ms debounce, then let the mocked promise chain settle.
+		await new Promise((resolve) => setTimeout(resolve, 350));
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+
+		expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ variables: { name: '%Amy%' } }));
+		expect(fixture.nativeElement.textContent).toContain('Amy Taylor');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.ts
@@ -1,0 +1,133 @@
+import { ChangeDetectionStrategy, Component, OnDestroy, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+
+// The $name variable is supplied at execution time via the `variables` argument.
+// UIAPI's `like` operator accepts SQL-style wildcards: %term% matches anywhere.
+const QUERY = gql`
+	query FilteredContacts($name: String) {
+		uiapi {
+			query {
+				Contact(where: { Name: { like: $name } }, first: 5, orderBy: { Name: { order: ASC } }) {
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+							Title @optional {
+								value
+							}
+							Phone @optional {
+								value
+							}
+							Picture__c @optional {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Filtered List with Variables
+ *
+ * Queries Contacts by name using a GraphQL variable bound to an input.
+ *
+ * LWC equivalent: a @track property bound to an input and passed to @wire —
+ * the adapter re-fires when the property changes. Here a debounced handler
+ * re-runs the query with a fresh $name variable.
+ *
+ * @see SortedResultsComponent — sorting results with a dynamic orderBy
+ */
+@Component({
+	selector: 'app-filtered-list',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	templateUrl: './filtered-list.html',
+})
+export class FilteredListComponent implements OnDestroy {
+	protected readonly search = signal('');
+	protected readonly contacts = signal<ContactFields[]>([]);
+	protected readonly loading = signal(false);
+	protected readonly error = signal<string | undefined>(undefined);
+
+	private timer?: ReturnType<typeof setTimeout>;
+
+	// Debounce: wait 300ms after the last keystroke before querying. Clearing the
+	// pending timer on each keystroke cancels the previous, in-flight request.
+	protected onSearch(value: string): void {
+		this.search.set(value);
+		clearTimeout(this.timer);
+		this.error.set(undefined);
+		if (!value.trim()) {
+			this.contacts.set([]);
+			return;
+		}
+		this.timer = setTimeout(() => this.fetch(value), 300);
+	}
+
+	ngOnDestroy(): void {
+		clearTimeout(this.timer);
+	}
+
+	private async fetch(term: string): Promise<void> {
+		this.loading.set(true);
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<FilteredContactsResponse>({
+				query: QUERY,
+				variables: { name: `%${term}%` },
+			});
+
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			const edges = result?.data?.uiapi?.query?.Contact?.edges ?? [];
+			this.contacts.set(
+				edges
+					.map((edge) => edge?.node)
+					.filter((node): node is ContactNode => node != null)
+					.map((node) => ({
+						id: node.Id,
+						name: node.Name?.value ?? 'Unknown',
+						title: node.Title?.value ?? null,
+						phone: node.Phone?.value ?? null,
+						pictureUrl: node.Picture__c?.value ?? null,
+					})),
+			);
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		} finally {
+			this.loading.set(false);
+		}
+	}
+}
+
+interface ContactNode {
+	Id: string;
+	Name: { value: string | null };
+	Title: { value: string | null };
+	Phone: { value: string | null };
+	Picture__c: { value: string | null };
+}
+
+interface FilteredContactsResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				edges: { node: ContactNode }[];
+			};
+		};
+	};
+}
+
+interface ContactFields {
+	id: string;
+	name: string;
+	title: string | null;
+	phone: string | null;
+	pictureUrl: string | null;
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/imperative-refetch/imperative-refetch.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/imperative-refetch/imperative-refetch.html
@@ -1,0 +1,32 @@
+<div>
+	<div class="flex items-center mb-2">
+		<!-- Unlike @wire, you decide when to re-fetch. -->
+		<app-button
+			appearance="outlined"
+			[loading]="loading()"
+			loadingLabel="Refreshing…"
+			(clicked)="refetch()"
+			>Refresh</app-button
+		>
+		<span class="text-xs text-muted-foreground ml-2">
+			Fetched {{ fetchCount() }} {{ fetchCount() === 1 ? 'time' : 'times' }}
+		</span>
+	</div>
+
+	@if (error(); as error) {
+		<p class="text-destructive">{{ error }}</p>
+	} @else if (!loading()) {
+		<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+			<ul>
+				@for (contact of contacts(); track contact.id) {
+					<li class="py-2 -mx-2 px-2 rounded-md transition-colors hover:bg-accent/50">
+						<p class="text-sm text-foreground">{{ contact.name }}</p>
+						@if (contact.title) {
+							<p class="text-xs text-muted-foreground">{{ contact.title }}</p>
+						}
+					</li>
+				}
+			</ul>
+		</div>
+	}
+</div>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/imperative-refetch/imperative-refetch.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/imperative-refetch/imperative-refetch.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { ImperativeRefetchComponent } from './imperative-refetch';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('ImperativeRefetchComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: {
+						Contact: { edges: [{ node: { Id: '1', Name: { value: 'Amy Taylor' }, Title: { value: null } } }] },
+					},
+				},
+			},
+		});
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('re-queries and increments the fetch count when Refresh is clicked', async () => {
+		await TestBed.configureTestingModule({ imports: [ImperativeRefetchComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(ImperativeRefetchComponent);
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		expect(mockQuery).toHaveBeenCalledTimes(1);
+		expect(fixture.nativeElement.textContent).toContain('Fetched 1 time');
+
+		(fixture.nativeElement.querySelector('app-button button') as HTMLButtonElement).click();
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		expect(mockQuery).toHaveBeenCalledTimes(2);
+		expect(fixture.nativeElement.textContent).toContain('Fetched 2 times');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/imperative-refetch/imperative-refetch.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/imperative-refetch/imperative-refetch.ts
@@ -1,0 +1,107 @@
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+import { ButtonImports } from '../../../components/ui/button/button';
+
+const QUERY = gql`
+	query RefetchContacts {
+		uiapi {
+			query {
+				Contact(first: 5, orderBy: { Name: { order: ASC } }) {
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+							Title @optional {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Imperative Refetch
+ *
+ * Displays a Contact list with a Refresh button that re-runs the query on
+ * demand.
+ *
+ * LWC equivalent: refreshApex() or notifyRecordUpdateAvailable() to force a
+ * @wire adapter to re-fetch. Here there is no cache to invalidate — you simply
+ * call the fetch method again.
+ *
+ * @see The Modify Data recipes — after a create/update/delete you call the
+ * fetch method again to reload, the same pattern shown here.
+ */
+@Component({
+	selector: 'app-imperative-refetch',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [ButtonImports],
+	templateUrl: './imperative-refetch.html',
+})
+export class ImperativeRefetchComponent implements OnInit {
+	protected readonly contacts = signal<ContactFields[]>([]);
+	protected readonly loading = signal(true);
+	protected readonly error = signal<string | undefined>(undefined);
+	protected readonly fetchCount = signal(0);
+
+	ngOnInit(): void {
+		this.refetch();
+	}
+
+	protected async refetch(): Promise<void> {
+		this.loading.set(true);
+		this.error.set(undefined);
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<QueryResponse>({ query: QUERY });
+
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			const edges = result?.data?.uiapi?.query?.Contact?.edges ?? [];
+			this.contacts.set(
+				edges
+					.map((edge) => edge?.node)
+					.filter((node): node is ContactNode => node != null)
+					.map((node) => ({
+						id: node.Id,
+						name: node.Name?.value ?? 'Unknown',
+						title: node.Title?.value ?? null,
+					})),
+			);
+			this.fetchCount.update((n) => n + 1);
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		} finally {
+			this.loading.set(false);
+		}
+	}
+}
+
+interface ContactNode {
+	Id: string;
+	Name: { value: string | null };
+	Title: { value: string | null };
+}
+
+interface QueryResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				edges: { node: ContactNode }[];
+			};
+		};
+	};
+}
+
+interface ContactFields {
+	id: string;
+	name: string;
+	title: string | null;
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/list-of-records/list-of-records.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/list-of-records/list-of-records.html
@@ -1,0 +1,35 @@
+@if (error(); as error) {
+	<p class="text-destructive">{{ error }}</p>
+} @else if (contacts(); as contacts) {
+	<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+		<ul>
+			<!-- @for replaces LWC's for:each; track the record Id for stable rendering. -->
+			@for (contact of contacts; track contact.id) {
+				<li class="py-2 -mx-2 px-2 rounded-md transition-colors hover:bg-accent/50">
+					<div class="flex items-center gap-3">
+						@if (contact.pictureUrl) {
+							<img
+								[src]="contact.pictureUrl"
+								[alt]="contact.name"
+								class="h-8 w-8 rounded-full object-cover"
+							/>
+						}
+						<div class="min-w-0">
+							<p class="text-sm text-foreground">{{ contact.name }}</p>
+							@if (contact.title) {
+								<p class="text-xs text-muted-foreground">{{ contact.title }}</p>
+							}
+							@if (contact.phone) {
+								<a [href]="'tel:' + contact.phone" class="text-xs text-primary hover:underline">{{
+									contact.phone
+								}}</a>
+							}
+						</div>
+					</div>
+				</li>
+			}
+		</ul>
+	</div>
+} @else {
+	<p class="text-sm">Loading…</p>
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/list-of-records/list-of-records.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/list-of-records/list-of-records.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { ListOfRecordsComponent } from './list-of-records';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('ListOfRecordsComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('renders one list item per Contact', async () => {
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: {
+						Contact: {
+							edges: [
+								{ node: { Id: '1', Name: { value: 'Amy Taylor' }, Title: { value: 'VP' }, Phone: { value: null }, Picture__c: { value: null } } },
+								{ node: { Id: '2', Name: { value: 'Brian King' }, Title: { value: null }, Phone: { value: null }, Picture__c: { value: null } } },
+							],
+						},
+					},
+				},
+			},
+		});
+		await TestBed.configureTestingModule({ imports: [ListOfRecordsComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(ListOfRecordsComponent);
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		const el = fixture.nativeElement as HTMLElement;
+		expect(el.querySelectorAll('li')).toHaveLength(2);
+		expect(el.textContent).toContain('Amy Taylor');
+		expect(el.textContent).toContain('Brian King');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/list-of-records/list-of-records.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/list-of-records/list-of-records.ts
@@ -1,0 +1,107 @@
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+
+// The Relay connection pattern wraps records in edges[].node rather than a
+// plain array — so the query asks for edges → node → fields.
+const QUERY = gql`
+	query ListContacts {
+		uiapi {
+			query {
+				Contact(where: { Picture__c: { ne: null } }, first: 5, orderBy: { Name: { order: ASC } }) {
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+							Title @optional {
+								value
+							}
+							Phone @optional {
+								value
+							}
+							Picture__c @optional {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * List of Records
+ *
+ * Queries multiple Contacts via UIAPI GraphQL and renders each one. The
+ * response uses the Relay connection shape, so records arrive as edges[].node.
+ *
+ * LWC equivalent: a @wire graphql adapter or an Apex method returning
+ * List<SObject>. Here you flatten edges → node into a plain array yourself.
+ *
+ * @see FilteredListComponent — adding a search filter with GraphQL variables
+ */
+@Component({
+	selector: 'app-list-of-records',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	templateUrl: './list-of-records.html',
+})
+export class ListOfRecordsComponent implements OnInit {
+	protected readonly contacts = signal<ContactFields[] | undefined>(undefined);
+	protected readonly error = signal<string | undefined>(undefined);
+
+	async ngOnInit(): Promise<void> {
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<ListContactsResponse>({ query: QUERY });
+
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			// edges can contain null nodes in UIAPI — filter before mapping.
+			const edges = result?.data?.uiapi?.query?.Contact?.edges ?? [];
+			this.contacts.set(
+				edges
+					.map((edge) => edge?.node)
+					.filter((node): node is ContactNode => node != null)
+					.map((node) => ({
+						id: node.Id,
+						name: node.Name?.value ?? 'Unknown',
+						title: node.Title?.value ?? null,
+						phone: node.Phone?.value ?? null,
+						pictureUrl: node.Picture__c?.value ?? null,
+					})),
+			);
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		}
+	}
+}
+
+interface ContactNode {
+	Id: string;
+	Name: { value: string | null };
+	Title: { value: string | null };
+	Phone: { value: string | null };
+	Picture__c: { value: string | null };
+}
+
+interface ListContactsResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				edges: { node: ContactNode }[];
+			};
+		};
+	};
+}
+
+interface ContactFields {
+	id: string;
+	name: string;
+	title: string | null;
+	phone: string | null;
+	pictureUrl: string | null;
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/paginated-list/paginated-list.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/paginated-list/paginated-list.html
@@ -1,0 +1,32 @@
+@if (loading()) {
+	<p class="text-sm">Loading…</p>
+} @else if (error(); as error) {
+	<p class="text-destructive">{{ error }}</p>
+} @else {
+	<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+		<ul>
+			@for (contact of contacts(); track contact.id) {
+				<li class="py-2 -mx-2 px-2 rounded-md transition-colors hover:bg-accent/50">
+					<p class="text-sm text-foreground">{{ contact.name }}</p>
+					@if (contact.title) {
+						<p class="text-xs text-muted-foreground">{{ contact.title }}</p>
+					}
+				</li>
+			}
+		</ul>
+
+		@if (hasNextPage()) {
+			<div class="mt-2">
+				<app-button
+					appearance="outlined"
+					[loading]="loadingMore()"
+					loadingLabel="Loading…"
+					(clicked)="loadMore()"
+					>Load More</app-button
+				>
+			</div>
+		} @else if (contacts().length > 0) {
+			<p class="text-xs text-muted-foreground mt-2">All {{ contacts().length }} contacts loaded.</p>
+		}
+	</div>
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/paginated-list/paginated-list.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/paginated-list/paginated-list.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { PaginatedListComponent } from './paginated-list';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+function page(ids: string[], hasNextPage: boolean, endCursor: string | null) {
+	return {
+		data: {
+			uiapi: {
+				query: {
+					Contact: {
+						pageInfo: { hasNextPage, endCursor },
+						edges: ids.map((id) => ({ node: { Id: id, Name: { value: `Contact ${id}` }, Title: { value: null } } })),
+					},
+				},
+			},
+		},
+	};
+}
+
+describe('PaginatedListComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('appends the next page on Load More using the endCursor', async () => {
+		mockQuery.mockResolvedValueOnce(page(['1', '2'], true, 'CURSOR_A'));
+		await TestBed.configureTestingModule({ imports: [PaginatedListComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(PaginatedListComponent);
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		expect(fixture.nativeElement.querySelectorAll('li')).toHaveLength(2);
+
+		mockQuery.mockResolvedValueOnce(page(['3', '4'], false, null));
+		(fixture.nativeElement.querySelector('app-button button') as HTMLButtonElement).click();
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+
+		expect(mockQuery.mock.calls[1][0].variables).toEqual({ after: 'CURSOR_A' });
+		expect(fixture.nativeElement.querySelectorAll('li')).toHaveLength(4);
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/paginated-list/paginated-list.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/paginated-list/paginated-list.ts
@@ -1,0 +1,139 @@
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+import { ButtonImports } from '../../../components/ui/button/button';
+
+// $after is an opaque cursor returned by pageInfo.endCursor. Pass it to fetch
+// the next page; omit it (or pass null) to start from the beginning.
+const QUERY = gql`
+	query PaginatedContacts($after: String) {
+		uiapi {
+			query {
+				Contact(first: 2, after: $after, orderBy: { Name: { order: ASC } }) {
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+							Title @optional {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Paginated List
+ *
+ * Fetches two Contacts at a time using Relay cursor pagination (first / after).
+ * Each "Load More" passes pageInfo.endCursor as $after and appends the next page.
+ *
+ * LWC equivalent: the @wire graphql adapter paginates with the same cursor
+ * pattern — pass endCursor as a reactive variable.
+ *
+ * @see RelatedRecordsComponent — traversing parent-child relationships
+ */
+@Component({
+	selector: 'app-paginated-list',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [ButtonImports],
+	templateUrl: './paginated-list.html',
+})
+export class PaginatedListComponent implements OnInit {
+	protected readonly contacts = signal<ContactFields[]>([]);
+	protected readonly hasNextPage = signal(false);
+	protected readonly loading = signal(true);
+	protected readonly loadingMore = signal(false);
+	protected readonly error = signal<string | undefined>(undefined);
+
+	// The cursor is plain state, not rendered — a private field, not a signal.
+	private endCursor: string | null = null;
+
+	async ngOnInit(): Promise<void> {
+		try {
+			const page = await this.fetchPage();
+			this.contacts.set(page.contacts);
+			this.hasNextPage.set(page.hasNextPage);
+			this.endCursor = page.endCursor;
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		} finally {
+			this.loading.set(false);
+		}
+	}
+
+	protected async loadMore(): Promise<void> {
+		if (!this.endCursor) return;
+		this.loadingMore.set(true);
+		try {
+			const page = await this.fetchPage(this.endCursor);
+			// Cursor pagination accumulates — append the new page to the list.
+			this.contacts.update((prev) => [...prev, ...page.contacts]);
+			this.hasNextPage.set(page.hasNextPage);
+			this.endCursor = page.endCursor;
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		} finally {
+			this.loadingMore.set(false);
+		}
+	}
+
+	private async fetchPage(
+		after?: string | null,
+	): Promise<{ contacts: ContactFields[]; hasNextPage: boolean; endCursor: string | null }> {
+		const sdk = await createDataSDK();
+		const variables = after ? { after } : {};
+		const result = await sdk.graphql?.query<PaginatedContactsResponse>({ query: QUERY, variables });
+
+		if (result?.errors?.length) {
+			throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+		}
+
+		const connection = result?.data?.uiapi?.query?.Contact;
+		const contacts = (connection?.edges ?? [])
+			.map((edge) => edge?.node)
+			.filter((node): node is ContactNode => node != null)
+			.map((node) => ({
+				id: node.Id,
+				name: node.Name?.value ?? 'Unknown',
+				title: node.Title?.value ?? null,
+			}));
+
+		return {
+			contacts,
+			hasNextPage: connection?.pageInfo?.hasNextPage ?? false,
+			endCursor: connection?.pageInfo?.endCursor ?? null,
+		};
+	}
+}
+
+interface ContactNode {
+	Id: string;
+	Name: { value: string | null };
+	Title: { value: string | null };
+}
+
+interface PaginatedContactsResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				pageInfo: { hasNextPage: boolean; endCursor: string | null };
+				edges: { node: ContactNode }[];
+			};
+		};
+	};
+}
+
+interface ContactFields {
+	id: string;
+	name: string;
+	title: string | null;
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/related-records/related-records.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/related-records/related-records.html
@@ -1,0 +1,33 @@
+@if (error(); as error) {
+	<p class="text-destructive">{{ error }}</p>
+} @else if (contacts(); as contacts) {
+	<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+		<div class="flex gap-4 mb-1 border-b border-border pb-1.5">
+			<span class="text-xs text-muted-foreground basis-1/2 shrink-0 grow-0"><strong>Contact</strong></span>
+			<span class="flex-1 text-xs text-muted-foreground"><strong>Account</strong></span>
+		</div>
+		<ul>
+			@for (contact of contacts; track contact.id) {
+				<li class="-mx-2 px-2 rounded-md transition-colors hover:bg-accent/50">
+					<div class="flex gap-4 items-center py-2">
+						<div class="basis-1/2 shrink-0 grow-0">
+							<span class="text-sm text-foreground">{{ contact.name }}</span>
+							@if (contact.title) {
+								<span class="text-xs text-muted-foreground ml-1">— {{ contact.title }}</span>
+							}
+						</div>
+						<div class="flex-1">
+							@if (contact.accountName) {
+								<span class="text-sm text-foreground">{{ contact.accountName }}</span>
+							} @else {
+								<em class="text-muted-foreground">—</em>
+							}
+						</div>
+					</div>
+				</li>
+			}
+		</ul>
+	</div>
+} @else {
+	<p class="text-sm">Loading…</p>
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/related-records/related-records.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/related-records/related-records.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { RelatedRecordsComponent } from './related-records';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('RelatedRecordsComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('renders each Contact with its parent Account name', async () => {
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: {
+						Contact: {
+							edges: [
+								{ node: { Id: '1', Name: { value: 'Amy Taylor' }, Title: { value: null }, Account: { Name: { value: 'Edge Communications' } } } },
+								{ node: { Id: '2', Name: { value: 'Brian King' }, Title: { value: null }, Account: null } },
+							],
+						},
+					},
+				},
+			},
+		});
+		await TestBed.configureTestingModule({ imports: [RelatedRecordsComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(RelatedRecordsComponent);
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		const el = fixture.nativeElement as HTMLElement;
+		expect(el.querySelectorAll('ul li')).toHaveLength(2);
+		expect(el.textContent).toContain('Edge Communications');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/related-records/related-records.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/related-records/related-records.ts
@@ -1,0 +1,105 @@
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+
+// To traverse a lookup, nest the parent object's fields under the relationship
+// name. Contact.AccountId becomes `Account { Name { value } }` — the GraphQL
+// equivalent of SOQL's Contact.Account.Name spanning field.
+const QUERY = gql`
+	query ContactsWithAccount {
+		uiapi {
+			query {
+				Contact(first: 10, orderBy: { Name: { order: ASC } }) {
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+							Title @optional {
+								value
+							}
+							Account {
+								Name @optional {
+									value
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Related Records
+ *
+ * Queries Contacts with their parent Account in one request, traversing a
+ * lookup relationship. In LWC this needs separate @wire calls; here one query
+ * covers both objects.
+ *
+ * LWC equivalent: @wire(getRecord) with spanning fields like
+ * 'Contact.Account.Name', or two separate @wire calls.
+ *
+ * @see AliasedMultiObjectQueryComponent — querying unrelated objects in one request
+ */
+@Component({
+	selector: 'app-related-records',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	templateUrl: './related-records.html',
+})
+export class RelatedRecordsComponent implements OnInit {
+	protected readonly contacts = signal<ContactWithAccount[] | undefined>(undefined);
+	protected readonly error = signal<string | undefined>(undefined);
+
+	async ngOnInit(): Promise<void> {
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<ContactsWithAccountResponse>({ query: QUERY });
+
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			const edges = result?.data?.uiapi?.query?.Contact?.edges ?? [];
+			this.contacts.set(
+				edges
+					.map((edge) => edge?.node)
+					.filter((node): node is ContactNode => node != null)
+					.map((node) => ({
+						id: node.Id,
+						name: node.Name?.value ?? 'Unknown',
+						title: node.Title?.value ?? null,
+						// The parent Account is nested under the relationship name.
+						accountName: node.Account?.Name?.value ?? null,
+					})),
+			);
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		}
+	}
+}
+
+interface ContactNode {
+	Id: string;
+	Name: { value: string | null };
+	Title: { value: string | null };
+	Account: { Name: { value: string | null } } | null;
+}
+
+interface ContactsWithAccountResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				edges: { node: ContactNode }[];
+			};
+		};
+	};
+}
+
+interface ContactWithAccount {
+	id: string;
+	name: string;
+	title: string | null;
+	accountName: string | null;
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/single-record/single-record.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/single-record/single-record.html
@@ -1,0 +1,35 @@
+@if (loading()) {
+	<p class="text-sm">Loading…</p>
+} @else if (error(); as error) {
+	<p class="text-destructive">{{ error }}</p>
+} @else if (contact(); as contact) {
+	<div class="rounded-md border border-border bg-card p-4">
+		<div class="flex items-center gap-3">
+			@if (contact.pictureUrl) {
+				<img
+					[src]="contact.pictureUrl"
+					[alt]="contact.name"
+					class="h-12 w-12 rounded-full object-cover"
+				/>
+			} @else {
+				<span
+					class="h-12 w-12 rounded-full bg-muted flex items-center justify-center text-sm font-medium"
+					>{{ contact.name[0] }}</span
+				>
+			}
+			<div class="min-w-0">
+				<p class="text-lg font-semibold">{{ contact.name }}</p>
+				@if (contact.title) {
+					<p class="text-xs text-muted-foreground">{{ contact.title }}</p>
+				}
+				@if (contact.phone) {
+					<a [href]="'tel:' + contact.phone" class="text-xs text-primary hover:underline">{{
+						contact.phone
+					}}</a>
+				}
+			</div>
+		</div>
+	</div>
+} @else {
+	<p>No contacts found.</p>
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/single-record/single-record.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/single-record/single-record.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { SingleRecordComponent } from './single-record';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('SingleRecordComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('renders the fetched Contact fields', async () => {
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: {
+						Contact: {
+							edges: [
+								{
+									node: {
+										Id: '1',
+										Name: { value: 'Amy Taylor' },
+										Title: { value: 'VP of Engineering' },
+										Phone: { value: '555-1000' },
+										Picture__c: { value: 'https://example.com/a.jpg' },
+									},
+								},
+							],
+						},
+					},
+				},
+			},
+		});
+		await TestBed.configureTestingModule({ imports: [SingleRecordComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(SingleRecordComponent);
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		const el = fixture.nativeElement as HTMLElement;
+		expect(el.textContent).toContain('Amy Taylor');
+		expect(el.textContent).toContain('VP of Engineering');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/single-record/single-record.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/single-record/single-record.ts
@@ -1,0 +1,110 @@
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+
+// UIAPI wraps every query under uiapi.query.<Object> using the Relay connection
+// shape (edges → node). Each scalar is wrapped in { value } — the same shape as
+// record.fields.Name.value in LWC. @optional lets a field resolve to null
+// instead of failing the whole query.
+const QUERY = gql`
+	query SingleContact {
+		uiapi {
+			query {
+				Contact(where: { Picture__c: { ne: null } }, first: 1, orderBy: { Name: { order: ASC } }) {
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+							Title @optional {
+								value
+							}
+							Phone @optional {
+								value
+							}
+							Picture__c @optional {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * Single Record
+ *
+ * Queries a single Contact via UIAPI GraphQL and displays its fields.
+ *
+ * LWC equivalent: @wire(getRecord) with a record Id and field list exposes
+ * data/error automatically. Here you fetch in ngOnInit and own loading, error,
+ * and data as signals.
+ *
+ * @see ListOfRecordsComponent — querying multiple records
+ */
+@Component({
+	selector: 'app-single-record',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	templateUrl: './single-record.html',
+})
+export class SingleRecordComponent implements OnInit {
+	protected readonly contact = signal<ContactFields | undefined>(undefined);
+	protected readonly loading = signal(true);
+	protected readonly error = signal<string | undefined>(undefined);
+
+	async ngOnInit(): Promise<void> {
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<SingleContactResponse>({ query: QUERY });
+
+			// GraphQL errors are returned in result.errors, not thrown — check first.
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			// Unwrap: uiapi → query → Contact → edges[0] → node, then flatten { value }.
+			const node = result?.data?.uiapi?.query?.Contact?.edges?.[0]?.node;
+			if (node) {
+				this.contact.set({
+					id: node.Id,
+					name: node.Name?.value ?? 'Unknown',
+					title: node.Title?.value ?? null,
+					phone: node.Phone?.value ?? null,
+					pictureUrl: node.Picture__c?.value ?? null,
+				});
+			}
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		} finally {
+			this.loading.set(false);
+		}
+	}
+}
+
+interface SingleContactResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				edges: {
+					node: {
+						Id: string;
+						Name: { value: string | null };
+						Title: { value: string | null };
+						Phone: { value: string | null };
+						Picture__c: { value: string | null };
+					};
+				}[];
+			};
+		};
+	};
+}
+
+interface ContactFields {
+	id: string;
+	name: string;
+	title: string | null;
+	phone: string | null;
+	pictureUrl: string | null;
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.html
@@ -1,0 +1,48 @@
+<div>
+	<div class="flex gap-4 items-center mb-2">
+		<div class="w-1/2">
+			<label class="text-sm font-medium mb-1 block" for="sort-field">Sort by</label>
+			<select
+				#f
+				id="sort-field"
+				class="w-full rounded-md border border-input px-3 py-2 text-sm"
+				(change)="onField(f.value)"
+			>
+				@for (opt of sortFields; track opt.value) {
+					<option [value]="opt.value" [selected]="opt.value === field()">{{ opt.label }}</option>
+				}
+			</select>
+		</div>
+		<div class="w-1/2">
+			<label class="text-sm font-medium mb-1 block" for="sort-dir">Direction</label>
+			<select
+				#d
+				id="sort-dir"
+				class="w-full rounded-md border border-input px-3 py-2 text-sm"
+				(change)="onDir(d.value)"
+			>
+				<option value="ASC" [selected]="dir() === 'ASC'">Ascending</option>
+				<option value="DESC" [selected]="dir() === 'DESC'">Descending</option>
+			</select>
+		</div>
+	</div>
+
+	@if (loading()) {
+		<p class="text-sm mb-2">Loading…</p>
+	} @else if (error(); as error) {
+		<p class="text-destructive">{{ error }}</p>
+	} @else {
+		<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+			<ul>
+				@for (contact of contacts(); track contact.id) {
+					<li class="py-2 -mx-2 px-2 rounded-md transition-colors hover:bg-accent/50">
+						<p class="text-sm text-foreground">{{ contact.name }}</p>
+						@if (contact.title) {
+							<p class="text-xs text-muted-foreground">{{ contact.title }}</p>
+						}
+					</li>
+				}
+			</ul>
+		</div>
+	}
+</div>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { SortedResultsComponent } from './sorted-results';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('SortedResultsComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: {
+						Contact: {
+							edges: [
+								{ node: { Id: '1', Name: { value: 'Amy Taylor' }, Title: { value: 'VP' } } },
+							],
+						},
+					},
+				},
+			},
+		});
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('loads sorted contacts on init and rebuilds the query when the direction changes', async () => {
+		await TestBed.configureTestingModule({ imports: [SortedResultsComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(SortedResultsComponent);
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('Amy Taylor');
+		expect(mockQuery.mock.calls[0][0].query).toContain('order: ASC');
+
+		const dir = fixture.nativeElement.querySelectorAll('select')[1] as HTMLSelectElement;
+		dir.value = 'DESC';
+		dir.dispatchEvent(new Event('change'));
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		expect(mockQuery.mock.calls[1][0].query).toContain('order: DESC');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.ts
@@ -1,0 +1,134 @@
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { createDataSDK } from '@salesforce/platform-sdk';
+
+type SortField = 'Name' | 'Title' | 'Phone';
+type SortDir = 'ASC' | 'DESC';
+
+const SORT_FIELDS: { value: SortField; label: string }[] = [
+	{ value: 'Name', label: 'Name' },
+	{ value: 'Title', label: 'Title' },
+	{ value: 'Phone', label: 'Phone' },
+];
+
+// orderBy can't be a GraphQL variable in UIAPI, so the field and direction are
+// interpolated into the query string, which is rebuilt whenever they change.
+// (This one query is a plain string rather than a gql tag for that reason.)
+function buildQuery(field: SortField, direction: SortDir): string {
+	return `
+		query SortedContacts {
+			uiapi {
+				query {
+					Contact(first: 10, orderBy: { ${field}: { order: ${direction} } }) {
+						edges {
+							node {
+								Id
+								Name @optional {
+									value
+								}
+								Title @optional {
+									value
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	`;
+}
+
+/**
+ * Sorted Results
+ *
+ * Fetches Contacts with an orderBy driven by component state. Changing the sort
+ * field or direction rebuilds and re-runs the query.
+ *
+ * LWC equivalent: pass a reactive sort property to @wire with the graphql
+ * adapter — the wire re-fires when it changes. Here the change handler reloads.
+ *
+ * @see PaginatedListComponent — cursor-based pagination with Load More
+ */
+@Component({
+	selector: 'app-sorted-results',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	templateUrl: './sorted-results.html',
+})
+export class SortedResultsComponent implements OnInit {
+	protected readonly sortFields = SORT_FIELDS;
+	protected readonly field = signal<SortField>('Name');
+	protected readonly dir = signal<SortDir>('ASC');
+	protected readonly contacts = signal<ContactFields[]>([]);
+	protected readonly loading = signal(true);
+	protected readonly error = signal<string | undefined>(undefined);
+
+	ngOnInit(): void {
+		this.load();
+	}
+
+	protected onField(value: string): void {
+		if (value === 'Name' || value === 'Title' || value === 'Phone') {
+			this.field.set(value);
+			this.load();
+		}
+	}
+
+	protected onDir(value: string): void {
+		if (value === 'ASC' || value === 'DESC') {
+			this.dir.set(value);
+			this.load();
+		}
+	}
+
+	private async load(): Promise<void> {
+		this.loading.set(true);
+		this.error.set(undefined);
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<SortedContactsResponse>({
+				query: buildQuery(this.field(), this.dir()),
+			});
+
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			const edges = result?.data?.uiapi?.query?.Contact?.edges ?? [];
+			this.contacts.set(
+				edges
+					.map((edge) => edge?.node)
+					.filter((node): node is ContactNode => node != null)
+					.map((node) => ({
+						id: node.Id,
+						name: node.Name?.value ?? 'Unknown',
+						title: node.Title?.value ?? null,
+					})),
+			);
+		} catch (err) {
+			this.error.set(err instanceof Error ? err.message : 'Request failed');
+		} finally {
+			this.loading.set(false);
+		}
+	}
+}
+
+interface ContactNode {
+	Id: string;
+	Name: { value: string | null };
+	Title: { value: string | null };
+}
+
+interface SortedContactsResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				edges: { node: ContactNode }[];
+			};
+		};
+	};
+}
+
+interface ContactFields {
+	id: string;
+	name: string;
+	title: string | null;
+}


### PR DESCRIPTION
### What does this PR do?

Ports the React Read Data category to Angular Recipes (8 recipes) — UIAPI GraphQL queries end to end:

- Single Record, List of Records — fetch-on-mount via ngOnInit, Relay edges[].node unwrapping, { value } scalar wrappers.
- Filtered List — debounced GraphQL $name variable bound to an input.
- Sorted Results — orderBy rebuilt from signals (orderBy can't be a variable).
- Paginated List — Relay cursor pagination (first / after) with Load More.
- Related Records — parent Account traversal via the lookup relationship.
- Aliased Multi-Object Query — Accounts + Contacts in one aliased request.
- Imperative Refetch — on-demand re-query with a Refresh button.

Each recipe is a standalone OnPush component with inlined createDataSDK + gql, explicit response interfaces, signals, and `@if`/`@for`; native styled inputs and the existing app-button are reused (no new UI primitives). Co-located specs mock createDataSDK. Wires the category into the route, registry, Home tile, and catalog; the navbar and search pick it up automatically.

Lint, build, and 31 unit tests pass.

## The PR fulfills these requirements:

- [X] Tests for the proposed changes have been added/updated.
- [X] Code linting and formatting was performed.