### PR TITLE
Add Error Handling recipes to Angular

### DIFF
--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/app.routes.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { AppLayoutComponent } from './components/layout/app-layout/app-layout';
 import { HomeComponent } from './pages/home/home';
 import { HelloComponent } from './pages/hello/hello';
+import { ErrorHandlingComponent } from './pages/error-handling/error-handling';
 import { NotFoundComponent } from './pages/not-found/not-found';
 
 export const routes: Routes = [
@@ -17,6 +18,11 @@ export const routes: Routes = [
 				path: 'hello',
 				component: HelloComponent,
 				data: { showInNavigation: true, label: 'Hello' },
+			},
+			{
+				path: 'error-handling',
+				component: ErrorHandlingComponent,
+				data: { showInNavigation: true, label: 'Error Handling' },
 			},
 			{
 				path: '**',

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/components/recipe/skeleton/skeleton.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/components/recipe/skeleton/skeleton.html
@@ -1,0 +1,9 @@
+@if (variant() === 'avatar') {
+	<span class="animate-pulse bg-muted rounded-full shrink-0 block" style="width: 3rem; height: 3rem"></span>
+} @else {
+	<div class="flex flex-col gap-1.5 w-full">
+		@for (i of rows(); track i) {
+			<span class="animate-pulse bg-muted rounded block h-3.5" [style.width]="widths[i % widths.length]"></span>
+		}
+	</div>
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/components/recipe/skeleton/skeleton.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/components/recipe/skeleton/skeleton.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+// Loading placeholder, mirroring the LWC lightning-skeleton-text /
+// lightning-skeleton-avatar API. Usage:
+//   <app-skeleton [lines]="3" />       — stacked text lines
+//   <app-skeleton variant="avatar" />  — circular avatar
+const LINE_WIDTHS = ['100%', '75%', '50%', '90%', '65%', '80%', '45%'];
+
+@Component({
+	selector: 'app-skeleton',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	templateUrl: './skeleton.html',
+})
+export class SkeletonComponent {
+	readonly variant = input<'text' | 'avatar'>('text');
+	readonly lines = input(1);
+
+	protected readonly widths = LINE_WIDTHS;
+	protected readonly rows = computed(() => Array.from({ length: this.lines() }, (_, i) => i));
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/error-handling/error-handling.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/error-handling/error-handling.html
@@ -1,0 +1,25 @@
+<app-recipe-gallery header="Error Handling">
+	<ng-template
+		appRecipe="Loading, Error, and Empty States"
+		description="Every async component must handle loading, error, and empty states explicitly. In LWC @wire hands you data and error automatically; here you own all four as a discriminated-union state machine in a signal. Use the simulate buttons to force each state."
+		[sources]="loadingSources"
+	>
+		<app-loading-error-empty />
+	</ng-template>
+
+	<ng-template
+		appRecipe="Error Boundary"
+		description="Angular has no render-time error boundary like React's class components. A throw during rendering reaches the application's ErrorHandler; to contain a failure to one region you guard the risky work and surface it through a signal. Break It triggers a failure, Try Again resets."
+		[sources]="boundarySources"
+	>
+		<app-error-boundary />
+	</ng-template>
+
+	<ng-template
+		appRecipe="GraphQL Errors"
+		description="Runs a query that requests a nonexistent field to trigger a GraphQL error. UIAPI returns these in result.errors[] rather than throwing — run both queries to see query-level errors versus thrown exceptions."
+		[sources]="graphqlSources"
+	>
+		<app-graphql-errors />
+	</ng-template>
+</app-recipe-gallery>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/error-handling/error-handling.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/error-handling/error-handling.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RecipeGalleryComponent } from '../../components/app/recipe-gallery/recipe-gallery';
+import { RecipeDirective } from '../../components/app/recipe-gallery/recipe.directive';
+import type { RecipeSource } from '../../components/app/code-block/code-block';
+import { LoadingErrorEmptyComponent } from '../../recipes/error-handling/loading-error-empty/loading-error-empty';
+import { ErrorBoundaryComponent } from '../../recipes/error-handling/error-boundary/error-boundary';
+import { GraphqlErrorsComponent } from '../../recipes/error-handling/graphql-errors/graphql-errors';
+
+// `?shiki` imports resolve to the file's highlighted source HTML (esbuild/shiki.mjs).
+import loadingTs from '../../recipes/error-handling/loading-error-empty/loading-error-empty.ts?shiki';
+import loadingHtml from '../../recipes/error-handling/loading-error-empty/loading-error-empty.html?shiki';
+import boundaryTs from '../../recipes/error-handling/error-boundary/error-boundary.ts?shiki';
+import boundaryHtml from '../../recipes/error-handling/error-boundary/error-boundary.html?shiki';
+import graphqlTs from '../../recipes/error-handling/graphql-errors/graphql-errors.ts?shiki';
+import graphqlHtml from '../../recipes/error-handling/graphql-errors/graphql-errors.html?shiki';
+
+@Component({
+	selector: 'app-error-handling',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [
+		RecipeGalleryComponent,
+		RecipeDirective,
+		LoadingErrorEmptyComponent,
+		ErrorBoundaryComponent,
+		GraphqlErrorsComponent,
+	],
+	templateUrl: './error-handling.html',
+})
+export class ErrorHandlingComponent {
+	protected readonly loadingSources: RecipeSource[] = [
+		{ label: 'loading-error-empty.ts', html: loadingTs },
+		{ label: 'loading-error-empty.html', html: loadingHtml },
+	];
+	protected readonly boundarySources: RecipeSource[] = [
+		{ label: 'error-boundary.ts', html: boundaryTs },
+		{ label: 'error-boundary.html', html: boundaryHtml },
+	];
+	protected readonly graphqlSources: RecipeSource[] = [
+		{ label: 'graphql-errors.ts', html: graphqlTs },
+		{ label: 'graphql-errors.html', html: graphqlHtml },
+	];
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/home/home.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/pages/home/home.ts
@@ -22,5 +22,12 @@ export class HomeComponent {
 				'Start here. Covers template binding, conditional and list rendering, lifecycle, and component composition with inputs and outputs.',
 			count: getRecipeCount('/hello'),
 		},
+		{
+			to: '/error-handling',
+			name: 'Error Handling',
+			description:
+				'Handle async states explicitly, contain failures without a render boundary, and read GraphQL errors from result.errors[].',
+			count: getRecipeCount('/error-handling'),
+		},
 	];
 }

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipe-registry.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipe-registry.ts
@@ -74,6 +74,31 @@ export const recipeRegistry: RecipeEntry[] = [
 		description:
 			'Two sibling components share a selected Account by lifting state to their common parent.',
 	},
+
+	// Error Handling
+	{
+		category: 'Error Handling',
+		categoryRoute: '/error-handling',
+		recipeIndex: 0,
+		name: 'Loading, Error, and Empty States',
+		description:
+			'Handles loading, error, and empty states explicitly with a discriminated-union signal.',
+	},
+	{
+		category: 'Error Handling',
+		categoryRoute: '/error-handling',
+		recipeIndex: 1,
+		name: 'Error Boundary',
+		description:
+			'Angular has no render boundary — guard the risky work and surface failures with a signal.',
+	},
+	{
+		category: 'Error Handling',
+		categoryRoute: '/error-handling',
+		recipeIndex: 2,
+		name: 'GraphQL Errors',
+		description: 'Reads query-level errors from result.errors[] and contrasts them with thrown exceptions.',
+	},
 ];
 
 /** Returns the number of recipes for a given category route (e.g. "/hello"). */

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/README.md
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/README.md
@@ -7,16 +7,20 @@ Angular Recipes are self-contained examples that teach one concept at a time. Ev
 More categories are being ported from React Recipes over time. Available today:
 
 1. **Hello** -- Angular fundamentals on Salesforce: template binding, conditional rendering, lists, inputs, outputs, signals, lifecycle
+2. **Error Handling** -- Loading/error/empty states, containing failures without a render boundary, and GraphQL errors
 
 ## Full Recipe Table
 
-| Category | Recipe                          | Description                                                                                     |
-| -------- | ------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Hello    | Hello World                     | The simplest possible Salesforce web application component.                                     |
-| Hello    | Binding to an Account Name      | Fetches an Account via UIAPI GraphQL and binds the Name field to the template.                  |
-| Hello    | Conditional Rendering           | Fetches an Account and conditionally renders different UI based on the Industry picklist value. |
-| Hello    | List Rendering (For Each)       | Fetches Accounts via GraphQL and renders them with the @for block.                              |
-| Hello    | Lifecycle (Fetch on Mount)      | Fetches a Contact in ngOnInit with cleanup to prevent stale updates.                            |
-| Hello    | Parent-to-Child (Inputs)        | The parent fetches Accounts via GraphQL and passes each one to a child component as inputs.     |
-| Hello    | Child-to-Parent (Outputs)       | A child component presents an Industry selector and emits an output to its parent.              |
-| Hello    | State Management (Shared State) | Two sibling components share a selected Account by lifting state to their common parent.        |
+| Category       | Recipe                           | Description                                                                                     |
+| -------------- | -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Hello          | Hello World                      | The simplest possible Salesforce web application component.                                     |
+| Hello          | Binding to an Account Name       | Fetches an Account via UIAPI GraphQL and binds the Name field to the template.                  |
+| Hello          | Conditional Rendering            | Fetches an Account and conditionally renders different UI based on the Industry picklist value. |
+| Hello          | List Rendering (For Each)        | Fetches Accounts via GraphQL and renders them with the @for block.                              |
+| Hello          | Lifecycle (Fetch on Mount)       | Fetches a Contact in ngOnInit with cleanup to prevent stale updates.                            |
+| Hello          | Parent-to-Child (Inputs)         | The parent fetches Accounts via GraphQL and passes each one to a child component as inputs.     |
+| Hello          | Child-to-Parent (Outputs)        | A child component presents an Industry selector and emits an output to its parent.              |
+| Hello          | State Management (Shared State)  | Two sibling components share a selected Account by lifting state to their common parent.        |
+| Error Handling | Loading, Error, and Empty States | Handles loading, error, and empty states explicitly with a discriminated-union signal.          |
+| Error Handling | Error Boundary                   | Angular has no render boundary — guard the risky work and surface failures with a signal.       |
+| Error Handling | GraphQL Errors                   | Reads query-level errors from result.errors[] and contrasts them with thrown exceptions.        |

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/error-boundary/error-boundary.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/error-boundary/error-boundary.html
@@ -1,0 +1,15 @@
+<div class="flex flex-col gap-4">
+	<app-button appearance="destructive" [disabled]="!!error()" (clicked)="breakIt()">Break It</app-button>
+
+	@if (error(); as message) {
+		<div class="rounded-md bg-rose-50 border border-rose-200 p-4 text-rose-700" role="alert">
+			<h2 class="text-base font-semibold mb-1">Caught the failure</h2>
+			<p class="text-sm mb-3">{{ message }}</p>
+			<app-button appearance="text" (clicked)="reset()">Try Again</app-button>
+		</div>
+	} @else {
+		<div class="rounded-md bg-muted p-4 text-sm">
+			Component rendered successfully. Click "Break It" to trigger a failure.
+		</div>
+	}
+</div>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/error-boundary/error-boundary.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/error-boundary/error-boundary.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+import { ErrorBoundaryComponent } from './error-boundary';
+
+describe('ErrorBoundaryComponent', () => {
+	it('contains the failure and shows a fallback, then resets', async () => {
+		await TestBed.configureTestingModule({ imports: [ErrorBoundaryComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(ErrorBoundaryComponent);
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('rendered successfully');
+
+		const buttons = () => fixture.nativeElement.querySelectorAll('app-button button');
+		(buttons()[0] as HTMLButtonElement).click();
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('Caught the failure');
+		expect(fixture.nativeElement.textContent).toContain('intentionally threw');
+
+		// Try Again is the second button once the fallback is showing.
+		(buttons()[1] as HTMLButtonElement).click();
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('rendered successfully');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/error-boundary/error-boundary.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/error-boundary/error-boundary.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ButtonImports } from '../../../components/ui/button/button';
+
+/**
+ * Error Boundary (the Angular way)
+ *
+ * Angular has no render-time error boundary like React's class components or
+ * LWC's errorCallback. A throw during change detection tears down the view and
+ * is reported to the application's ErrorHandler (registered globally, e.g. via
+ * provideBrowserGlobalErrorListeners or a custom ErrorHandler in app.config).
+ *
+ * To contain a failure to one region — the job a boundary does in React — you
+ * guard the risky work yourself and surface the failure through a signal so the
+ * template renders a fallback instead of crashing. Click "Break It" to trigger a
+ * failure, then "Try Again" to reset.
+ *
+ * @see LoadingErrorEmptyComponent — explicit loading/error/empty states
+ */
+@Component({
+	selector: 'app-error-boundary',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [ButtonImports],
+	templateUrl: './error-boundary.html',
+})
+export class ErrorBoundaryComponent {
+	protected readonly error = signal<string | undefined>(undefined);
+
+	protected breakIt(): void {
+		try {
+			this.renderWidget();
+		} catch (err) {
+			// Contain the failure here rather than letting it reach the global
+			// ErrorHandler and tear down the view.
+			this.error.set(err instanceof Error ? err.message : 'Render failed');
+		}
+	}
+
+	protected reset(): void {
+		this.error.set(undefined);
+	}
+
+	// Stands in for risky work — building a widget, parsing a response, etc.
+	private renderWidget(): void {
+		throw new Error('Render error: the widget intentionally threw');
+	}
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/graphql-errors/graphql-errors.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/graphql-errors/graphql-errors.html
@@ -1,0 +1,38 @@
+<div>
+	<div class="flex gap-2 mb-2">
+		<app-button appearance="destructive" [disabled]="loading()" (clicked)="runBad()"
+			>Run Bad Query</app-button
+		>
+		<app-button [disabled]="loading()" (clicked)="runGood()">Run Good Query</app-button>
+	</div>
+
+	@if (loading()) {
+		<p class="text-sm">Executing…</p>
+	}
+
+	@if (errors(); as errors) {
+		<div class="rounded-md bg-rose-50 border border-rose-200 p-4 text-rose-700" role="alert">
+			<p class="text-xs mb-1">
+				<strong>{{ errors.length }} error{{ errors.length > 1 ? 's' : '' }} returned</strong>
+			</p>
+			<ul class="list-disc pl-5">
+				@for (e of errors; track $index) {
+					<li class="text-xs">
+						{{ e.message }}
+						@if (e.path; as path) {
+							@if (path.length) {
+								<span class="opacity-70"> — path: {{ path.join('.') }}</span>
+							}
+						}
+					</li>
+				}
+			</ul>
+		</div>
+	}
+
+	@if (success(); as success) {
+		<div class="rounded-md bg-emerald-50 border border-emerald-200 p-4 text-emerald-700" role="status">
+			<p class="text-xs">{{ success }}</p>
+		</div>
+	}
+</div>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/graphql-errors/graphql-errors.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/graphql-errors/graphql-errors.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { GraphqlErrorsComponent } from './graphql-errors';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+describe('GraphqlErrorsComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('surfaces query-level errors from result.errors', async () => {
+		mockQuery.mockResolvedValue({ errors: [{ message: "Field 'NonExistentField__c' doesn't exist" }] });
+		await TestBed.configureTestingModule({ imports: [GraphqlErrorsComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(GraphqlErrorsComponent);
+		fixture.detectChanges();
+		(fixture.nativeElement.querySelectorAll('app-button button')[0] as HTMLButtonElement).click();
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('1 error returned');
+		expect(fixture.nativeElement.textContent).toContain("doesn't exist");
+	});
+
+	it('renders the error path when UIAPI includes one', async () => {
+		mockQuery.mockResolvedValue({
+			errors: [{ message: 'Bad field', path: ['uiapi', 'query', 'Account'] }],
+		});
+		await TestBed.configureTestingModule({ imports: [GraphqlErrorsComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(GraphqlErrorsComponent);
+		fixture.detectChanges();
+		(fixture.nativeElement.querySelectorAll('app-button button')[0] as HTMLButtonElement).click();
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('path: uiapi.query.Account');
+	});
+
+	it('shows a success message when the query returns no errors', async () => {
+		mockQuery.mockResolvedValue({ data: { uiapi: { query: { Account: { edges: [] } } } } });
+		await TestBed.configureTestingModule({ imports: [GraphqlErrorsComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(GraphqlErrorsComponent);
+		fixture.detectChanges();
+		(fixture.nativeElement.querySelectorAll('app-button button')[1] as HTMLButtonElement).click();
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('succeeded — no errors');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/graphql-errors/graphql-errors.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/graphql-errors/graphql-errors.ts
@@ -1,0 +1,110 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+import { ButtonImports } from '../../../components/ui/button/button';
+
+// Intentionally asks for a field that doesn't exist on Account. UIAPI returns
+// a result.errors[] array rather than throwing — so it's a plain string, not a
+// gql tag (there's nothing valid to highlight).
+const BAD_QUERY = `
+	query BadAccountQuery {
+		uiapi {
+			query {
+				Account(first: 1) {
+					edges {
+						node {
+							Id
+							NonExistentField__c {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+const GOOD_QUERY = gql`
+	query GoodAccountQuery {
+		uiapi {
+			query {
+				Account(first: 1) {
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+/**
+ * GraphQL Error Handling
+ *
+ * Runs a query that requests a nonexistent field. UIAPI surfaces such problems
+ * in result.errors[] (each with a message and often a path) rather than
+ * throwing — so there are two layers to handle: query-level errors you read off
+ * the result, and thrown exceptions (network/SDK) you catch. Run both queries
+ * to see the difference.
+ *
+ * LWC equivalent: @wire with the GraphQL adapter hands you problems via its
+ * error property; here you read them off result.errors[] yourself.
+ *
+ * @see ErrorBoundaryComponent — containing render-time exceptions
+ */
+@Component({
+	selector: 'app-graphql-errors',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [ButtonImports],
+	templateUrl: './graphql-errors.html',
+})
+export class GraphqlErrorsComponent {
+	protected readonly errors = signal<GraphqlError[] | undefined>(undefined);
+	protected readonly success = signal<string | undefined>(undefined);
+	protected readonly loading = signal(false);
+
+	protected runBad(): void {
+		this.run(BAD_QUERY, 'Bad query');
+	}
+
+	protected runGood(): void {
+		this.run(GOOD_QUERY, 'Good query');
+	}
+
+	private async run(query: string, label: string): Promise<void> {
+		this.loading.set(true);
+		this.errors.set(undefined);
+		this.success.set(undefined);
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query({ query });
+
+			// Layer 1: query-level errors (bad fields, auth, etc.) — returned, not thrown.
+			if (result?.errors?.length) {
+				this.errors.set(
+					result.errors.map((e: GraphqlError) => ({ message: e.message, path: e.path })),
+				);
+				return;
+			}
+
+			this.success.set(`${label} succeeded — no errors.`);
+		} catch (err) {
+			// Layer 2: thrown exceptions — network failures, SDK errors.
+			this.errors.set([{ message: err instanceof Error ? err.message : 'Request failed' }]);
+		} finally {
+			this.loading.set(false);
+		}
+	}
+}
+
+interface GraphqlError {
+	message: string;
+	// UIAPI usually includes the path to the offending field, e.g.
+	// ["uiapi","query","Account"]. Thrown (network/SDK) errors have no path.
+	path?: string[];
+}

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/loading-error-empty/loading-error-empty.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/loading-error-empty/loading-error-empty.html
@@ -1,0 +1,66 @@
+<div class="flex flex-col gap-4">
+	<div class="flex flex-wrap gap-2">
+		<app-button appearance="outlined" (clicked)="load()">Reload</app-button>
+		<app-button appearance="outlined" (clicked)="simulateLoading()">Simulate: Loading</app-button>
+		<app-button appearance="outlined" (clicked)="simulateError()">Simulate: Error</app-button>
+		<app-button appearance="outlined" (clicked)="simulateEmpty()">Simulate: Empty</app-button>
+	</div>
+
+	@switch (state().status) {
+		@case ('loading') {
+			<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+				<ul>
+					@for (i of [0, 1, 2]; track i) {
+						<li class="py-2 flex items-center gap-4">
+							<app-skeleton variant="avatar" />
+							<app-skeleton [lines]="3" />
+						</li>
+					}
+				</ul>
+			</div>
+		}
+		@case ('error') {
+			<div class="rounded-md bg-rose-50 border border-rose-200 p-4 text-rose-700" role="alert">
+				<p class="text-base font-semibold mb-1">Something went wrong</p>
+				<p class="text-sm mb-3">{{ errorMessage() }}</p>
+				<app-button appearance="text" (clicked)="load()">Try Again</app-button>
+			</div>
+		}
+		@case ('empty') {
+			<div class="rounded-md border border-dashed border-border bg-card/50 text-center p-6">
+				<p class="text-lg font-semibold mb-1">No Contacts Found</p>
+				<p class="text-sm text-muted-foreground">Your query returned no results.</p>
+			</div>
+		}
+		@case ('data') {
+			<div class="rounded-md border border-border bg-card p-4 shadow-sm">
+				<ul>
+					@for (contact of contacts(); track contact.id) {
+						<li
+							class="py-2 -mx-2 px-2 flex items-center gap-4 rounded-md transition-colors hover:bg-accent/50"
+						>
+							@if (contact.picture) {
+								<img
+									[src]="contact.picture"
+									[alt]="contact.name"
+									class="h-12 w-12 rounded-full object-cover"
+								/>
+							}
+							<div>
+								<p class="text-xs"><strong>{{ contact.name }}</strong></p>
+								@if (contact.title) {
+									<p class="text-xs text-muted-foreground">{{ contact.title }}</p>
+								}
+								@if (contact.phone) {
+									<a [href]="'tel:' + contact.phone" class="text-xs text-primary hover:underline">{{
+										contact.phone
+									}}</a>
+								}
+							</div>
+						</li>
+					}
+				</ul>
+			</div>
+		}
+	}
+</div>

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/loading-error-empty/loading-error-empty.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/loading-error-empty/loading-error-empty.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import type { Mock } from 'vitest';
+import { createDataSDK } from '@salesforce/platform-sdk';
+import { LoadingErrorEmptyComponent } from './loading-error-empty';
+
+vi.mock('@salesforce/platform-sdk', () => ({
+	createDataSDK: vi.fn(),
+	gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+const mockQuery = vi.fn();
+
+async function render() {
+	await TestBed.configureTestingModule({ imports: [LoadingErrorEmptyComponent] }).compileComponents();
+	const fixture = TestBed.createComponent(LoadingErrorEmptyComponent);
+	await fixture.whenStable();
+	await new Promise((resolve) => setTimeout(resolve));
+	fixture.detectChanges();
+	return fixture;
+}
+
+describe('LoadingErrorEmptyComponent', () => {
+	beforeEach(() => {
+		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('renders the data state when contacts are returned', async () => {
+		mockQuery.mockResolvedValue({
+			data: {
+				uiapi: {
+					query: { Contact: { edges: [{ node: { Id: '1', Name: { value: 'Amy Taylor' }, Phone: { value: null }, Picture__c: { value: null }, Title: { value: null } } }] } },
+				},
+			},
+		});
+		const fixture = await render();
+		expect(fixture.nativeElement.textContent).toContain('Amy Taylor');
+	});
+
+	it('renders the empty state when no contacts are returned', async () => {
+		mockQuery.mockResolvedValue({ data: { uiapi: { query: { Contact: { edges: [] } } } } });
+		const fixture = await render();
+		expect(fixture.nativeElement.textContent).toContain('No Contacts Found');
+	});
+
+	it('renders the error state on the Simulate: Error control', async () => {
+		mockQuery.mockResolvedValue({ data: { uiapi: { query: { Contact: { edges: [] } } } } });
+		const fixture = await render();
+		const buttons = fixture.nativeElement.querySelectorAll('app-button button');
+		(buttons[2] as HTMLButtonElement).click();
+		fixture.detectChanges();
+		expect(fixture.nativeElement.textContent).toContain('Something went wrong');
+		expect(fixture.nativeElement.textContent).toContain('Network request failed');
+	});
+});

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/loading-error-empty/loading-error-empty.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/error-handling/loading-error-empty/loading-error-empty.ts
@@ -1,0 +1,148 @@
+import { ChangeDetectionStrategy, Component, OnInit, computed, signal } from '@angular/core';
+import { createDataSDK, gql } from '@salesforce/platform-sdk';
+import { ButtonImports } from '../../../components/ui/button/button';
+import { SkeletonComponent } from '../../../components/recipe/skeleton/skeleton';
+
+const QUERY = gql`
+	query ContactsWithPicture {
+		uiapi {
+			query {
+				Contact(where: { Picture__c: { ne: null } }, first: 3, orderBy: { Name: { order: ASC } }) {
+					edges {
+						node {
+							Id
+							Name @optional {
+								value
+							}
+							Phone @optional {
+								value
+							}
+							Picture__c @optional {
+								value
+							}
+							Title @optional {
+								value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+`;
+
+// A discriminated union makes the four states mutually exclusive — you can't
+// accidentally render data while still "loading". This is the type-level
+// equivalent of LWC's if:true={data} / if:true={error} template guards.
+type AsyncState =
+	| { status: 'loading' }
+	| { status: 'error'; message: string }
+	| { status: 'empty' }
+	| { status: 'data'; contacts: ContactFields[] };
+
+/**
+ * Loading, Error, and Empty States
+ *
+ * Every async component must handle loading, error, and empty states
+ * explicitly. In LWC @wire hands you data and error automatically; here you own
+ * all four as a discriminated-union state machine held in a signal. The
+ * simulate buttons force each state on demand.
+ *
+ * @see GraphqlErrorsComponent — inspecting GraphQL error objects
+ */
+@Component({
+	selector: 'app-loading-error-empty',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [ButtonImports, SkeletonComponent],
+	templateUrl: './loading-error-empty.html',
+})
+export class LoadingErrorEmptyComponent implements OnInit {
+	protected readonly state = signal<AsyncState>({ status: 'loading' });
+
+	// Computed accessors narrow the union in TypeScript so the template stays
+	// cast-free while still reacting to state changes.
+	protected readonly errorMessage = computed(() => {
+		const s = this.state();
+		return s.status === 'error' ? s.message : '';
+	});
+	protected readonly contacts = computed(() => {
+		const s = this.state();
+		return s.status === 'data' ? s.contacts : [];
+	});
+
+	ngOnInit(): void {
+		this.fetch();
+	}
+
+	protected load(): void {
+		this.state.set({ status: 'loading' });
+		this.fetch();
+	}
+
+	protected simulateLoading(): void {
+		this.state.set({ status: 'loading' });
+	}
+
+	protected simulateError(): void {
+		this.state.set({ status: 'error', message: 'Network request failed' });
+	}
+
+	protected simulateEmpty(): void {
+		this.state.set({ status: 'empty' });
+	}
+
+	private async fetch(): Promise<void> {
+		try {
+			const sdk = await createDataSDK();
+			const result = await sdk.graphql?.query<QueryResponse>({ query: QUERY });
+
+			if (result?.errors?.length) {
+				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
+			}
+
+			const contacts = (result?.data?.uiapi?.query?.Contact?.edges ?? [])
+				.map((edge) => edge?.node)
+				.filter((node): node is ContactNode => node != null)
+				.map((node) => ({
+					id: node.Id,
+					name: node.Name?.value ?? 'Unknown',
+					phone: node.Phone?.value ?? null,
+					picture: node.Picture__c?.value ?? null,
+					title: node.Title?.value ?? null,
+				}));
+
+			this.state.set(contacts.length ? { status: 'data', contacts } : { status: 'empty' });
+		} catch (err) {
+			this.state.set({
+				status: 'error',
+				message: err instanceof Error ? err.message : 'Request failed',
+			});
+		}
+	}
+}
+
+interface ContactNode {
+	Id: string;
+	Name: { value: string | null } | null;
+	Phone: { value: string | null } | null;
+	Picture__c: { value: string | null } | null;
+	Title: { value: string | null } | null;
+}
+
+interface QueryResponse {
+	uiapi: {
+		query: {
+			Contact: {
+				edges: { node: ContactNode }[];
+			};
+		};
+	};
+}
+
+interface ContactFields {
+	id: string;
+	name: string;
+	phone: string | null;
+	picture: string | null;
+	title: string | null;
+}


### PR DESCRIPTION
### What does this PR do?

Port the React Error Handling category to Angular Recipes (3 recipes):

- Loading, Error, and Empty States — a discriminated-union AsyncState held in a signal, with computed accessors that narrow the union so the template stays cast-free; simulate buttons force each state. Adds a shared Skeleton helper.
- Error Boundary — Angular has no render-time boundary (unlike React's class component or LWC's errorCallback), so this teaches the idiomatic substitute: guard the risky work and surface the failure through a signal fallback, with the app-level ErrorHandler noted as the catch-all for the uncaught rest.
- GraphQL Errors — reads query-level errors from result.errors[] and contrasts them with thrown exceptions.

Standalone OnPush components, inline createDataSDK + gql, signals, @if/@switch, existing app-button reused. Co-located specs. Wires the category into the route, registry, Home tile, and catalog.

Llint, build, and 29 unit tests pass.

## The PR fulfills these requirements:

- [X] Tests for the proposed changes have been added/updated.
- [X] Code linting and formatting was performed.
