### PR TITLE
fix(embedding): sync UnsavedChanges form to host updates when pristine

### DIFF
--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.spec.ts
@@ -5,9 +5,21 @@ import { UnsavedChangesComponent } from './unsaved-changes';
 
 vi.mock('@salesforce/platform-sdk', () => ({ getViewSDK: vi.fn() }));
 
-function stubView(props: Record<string, unknown>) {
+function stubView(initial: Record<string, unknown>) {
+	const listeners: ((next: { props: Record<string, unknown> }) => void)[] = [];
+	const state = { props: initial };
 	return {
-		getUiState: () => ({ state: { props }, subscribe: () => () => undefined }),
+		getUiState: () => ({
+			state,
+			subscribe: (cb: (next: { props: Record<string, unknown> }) => void) => {
+				listeners.push(cb);
+				return () => undefined;
+			},
+		}),
+		emit: (next: Record<string, unknown>) => {
+			state.props = next;
+			listeners.forEach((cb) => cb({ props: next }));
+		},
 		dispatchEvent: vi.fn(),
 		markDirtyState: vi.fn(),
 		clearDirtyState: vi.fn(),
@@ -45,5 +57,31 @@ describe('UnsavedChangesComponent', () => {
 		const event = view.dispatchEvent.mock.calls[0][0] as CustomEvent;
 		expect(event.type).toBe('guestsave');
 		expect(event.detail).toEqual({ name: 'Acme', rating: 'Warm', type: 'Prospect' });
+	});
+
+	it('adopts a later host update while the form is pristine', async () => {
+		const view = stubView({ recordId: '001', name: 'Acme', rating: 'Warm', type: 'Prospect' });
+		(getViewSDK as Mock).mockResolvedValue(view);
+		const fixture = await render();
+		const component = fixture.componentInstance as unknown as { form(): { name?: string | null } };
+
+		view.emit({ recordId: '001', name: 'Acme Renamed', rating: 'Hot', type: 'Prospect' });
+
+		expect(component.form().name).toBe('Acme Renamed');
+	});
+
+	it('keeps in-progress edits when the host updates in the background', async () => {
+		const view = stubView({ recordId: '001', name: 'Acme', rating: 'Warm', type: 'Prospect' });
+		(getViewSDK as Mock).mockResolvedValue(view);
+		const fixture = await render();
+
+		const component = fixture.componentInstance as unknown as {
+			setName(value: string): void;
+			form(): { name?: string | null };
+		};
+		component.setName('My Draft');
+		view.emit({ recordId: '001', name: 'Server Rename', rating: 'Cold', type: 'Prospect' });
+
+		expect(component.form().name).toBe('My Draft');
 	});
 });

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.spec.ts
@@ -59,15 +59,19 @@ describe('UnsavedChangesComponent', () => {
 		expect(event.detail).toEqual({ name: 'Acme', rating: 'Warm', type: 'Prospect' });
 	});
 
-	it('adopts a later host update while the form is pristine', async () => {
+	it('adopts a later host update while the form is pristine, without marking dirty', async () => {
 		const view = stubView({ recordId: '001', name: 'Acme', rating: 'Warm', type: 'Prospect' });
 		(getViewSDK as Mock).mockResolvedValue(view);
 		const fixture = await render();
 		const component = fixture.componentInstance as unknown as { form(): { name?: string | null } };
+		view.markDirtyState.mockClear();
 
 		view.emit({ recordId: '001', name: 'Acme Renamed', rating: 'Hot', type: 'Prospect' });
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
 
 		expect(component.form().name).toBe('Acme Renamed');
+		expect(view.markDirtyState).not.toHaveBeenCalled();
 	});
 
 	it('keeps in-progress edits when the host updates in the background', async () => {
@@ -83,5 +87,28 @@ describe('UnsavedChangesComponent', () => {
 		view.emit({ recordId: '001', name: 'Server Rename', rating: 'Cold', type: 'Prospect' });
 
 		expect(component.form().name).toBe('My Draft');
+	});
+
+	it('adopts the host echo after a save, even when the host normalized the values', async () => {
+		const view = stubView({ recordId: '001', name: 'Acme', rating: 'Warm', type: 'Prospect' });
+		(getViewSDK as Mock).mockResolvedValue(view);
+		const fixture = await render();
+		const component = fixture.componentInstance as unknown as {
+			setName(value: string): void;
+			form(): { name?: string | null };
+			isDirty(): boolean;
+		};
+
+		component.setName('  Umbrella  ');
+		const save = fixture.nativeElement.querySelector('app-button button') as HTMLButtonElement;
+		save.click();
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+
+		// Host trimmed the value and echoed the normalized form back.
+		view.emit({ recordId: '001', name: 'Umbrella', rating: 'Warm', type: 'Prospect' });
+
+		expect(component.form().name).toBe('Umbrella');
+		expect(component.isDirty()).toBe(false);
 	});
 });

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.ts
@@ -71,8 +71,7 @@ export class UnsavedChangesComponent implements OnInit, OnDestroy {
 			this.form().type !== this.saved().type,
 	);
 
-	// Seeded once the host sends a payload with a recordId, so later host echoes
-	// don't clobber in-progress edits.
+	// Set once the host sends a payload with a recordId.
 	private seeded = false;
 	// Stops rapid Save re-clicks from firing duplicate updateRecords.
 	private saving = false;
@@ -115,11 +114,14 @@ export class UnsavedChangesComponent implements OnInit, OnDestroy {
 	}
 
 	private seed(props: AccountProps): void {
+		// Adopt the host's values into the form when the user has nothing in
+		// progress: the first payload, a form still matching the last saved values,
+		// or the echo from our own save (the host may normalize what it stored).
+		// If the user has unsaved edits, keep them.
+		const canAdopt = !this.seeded || !this.isDirty() || this.saving;
 		this.saved.set(props);
-		if (!this.seeded && props.recordId) {
-			this.form.set(props);
-			this.seeded = true;
-		}
+		if (canAdopt) this.form.set(props);
+		if (props.recordId) this.seeded = true;
 	}
 
 	protected setName(value: string): void {

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/embedding/unsaved-changes/unsaved-changes.ts
@@ -115,9 +115,9 @@ export class UnsavedChangesComponent implements OnInit, OnDestroy {
 
 	private seed(props: AccountProps): void {
 		// Adopt the host's values into the form when the user has nothing in
-		// progress: the first payload, a form still matching the last saved values,
-		// or the echo from our own save (the host may normalize what it stored).
-		// If the user has unsaved edits, keep them.
+		// progress. That means the first payload, a form still matching the last
+		// saved values, or the echo from our own save (which the host may
+		// normalize). Otherwise keep the user's in-progress edits.
 		const canAdopt = !this.seeded || !this.isDirty() || this.saving;
 		this.saved.set(props);
 		if (canAdopt) this.form.set(props);

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.test.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.test.tsx
@@ -162,6 +162,61 @@ describe('UnsavedChanges', () => {
     );
   });
 
+  it('adopts a later host update while the form is pristine', async () => {
+    const view = stubView({
+      recordId: '001',
+      name: 'Acme',
+      rating: 'Warm',
+      type: 'Prospect',
+    });
+    mockView(view);
+
+    render(<UnsavedChanges />);
+    await flushSdk();
+
+    act(() => {
+      view.emit({
+        recordId: '001',
+        name: 'Acme Renamed',
+        rating: 'Hot',
+        type: 'Prospect',
+      });
+    });
+
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe(
+      'Acme Renamed'
+    );
+  });
+
+  it('keeps in-progress edits when the host updates in the background', async () => {
+    const user = userEvent.setup();
+    const view = stubView({
+      recordId: '001',
+      name: 'Acme',
+      rating: 'Warm',
+      type: 'Prospect',
+    });
+    mockView(view);
+
+    render(<UnsavedChanges />);
+    await flushSdk();
+
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My Draft');
+
+    act(() => {
+      view.emit({
+        recordId: '001',
+        name: 'Server Rename',
+        rating: 'Cold',
+        type: 'Prospect',
+      });
+    });
+
+    expect(nameInput.value).toBe('My Draft');
+  });
+
   it('is accessible', async () => {
     mockView(
       stubView({

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.test.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.test.tsx
@@ -162,7 +162,7 @@ describe('UnsavedChanges', () => {
     );
   });
 
-  it('adopts a later host update while the form is pristine', async () => {
+  it('adopts a later host update while the form is pristine, without marking dirty', async () => {
     const view = stubView({
       recordId: '001',
       name: 'Acme',
@@ -173,6 +173,7 @@ describe('UnsavedChanges', () => {
 
     render(<UnsavedChanges />);
     await flushSdk();
+    view.markDirtyState.mockClear();
 
     act(() => {
       view.emit({
@@ -182,10 +183,12 @@ describe('UnsavedChanges', () => {
         type: 'Prospect',
       });
     });
+    await flushSdk();
 
     expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe(
       'Acme Renamed'
     );
+    expect(view.markDirtyState).not.toHaveBeenCalled();
   });
 
   it('keeps in-progress edits when the host updates in the background', async () => {
@@ -215,6 +218,41 @@ describe('UnsavedChanges', () => {
     });
 
     expect(nameInput.value).toBe('My Draft');
+  });
+
+  it('adopts the host echo after a save, even when the host normalized the values', async () => {
+    const user = userEvent.setup();
+    const view = stubView({
+      recordId: '001',
+      name: 'Acme',
+      rating: 'Warm',
+      type: 'Prospect',
+    });
+    mockView(view);
+
+    render(<UnsavedChanges />);
+    await flushSdk();
+
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+    await user.clear(nameInput);
+    await user.type(nameInput, '  Umbrella  ');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await flushSdk();
+
+    // Host trimmed the value and echoed the normalized form back.
+    act(() => {
+      view.emit({
+        recordId: '001',
+        name: 'Umbrella',
+        rating: 'Warm',
+        type: 'Prospect',
+      });
+    });
+    await flushSdk();
+
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe(
+      'Umbrella'
+    );
   });
 
   it('is accessible', async () => {

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.tsx
@@ -77,9 +77,9 @@ export default function UnsavedChanges() {
       if (!ui) return;
       const seed = (p: AccountProps) => {
         // Adopt the host's values into the form when the user has nothing in
-        // progress: the first payload, a form still matching the last saved
-        // values, or the echo from our own save (the host may normalize what it
-        // stored). If the user has unsaved edits, keep them.
+        // progress. That means the first payload, a form still matching the last
+        // saved values, or the echo from our own save (which the host may
+        // normalize). Otherwise keep the user's in-progress edits.
         const prevSaved = savedRef.current;
         const wasSeeded = seededRef.current;
         const wasSaving = savingRef.current;

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/embedding/UnsavedChanges.tsx
@@ -55,8 +55,10 @@ const TYPES = [
 export default function UnsavedChanges() {
   const [saved, setSaved] = useState<AccountProps>({});
   const [form, setForm] = useState<AccountProps>({});
-  // Seeded once the host sends a payload with a recordId; keeps the form
-  // in sync with subsequent host echoes only if the user hasn't edited yet.
+  // Mirrors `saved` so the ui-state subscription can compare against the last
+  // saved values synchronously (the state captured in that closure is stale).
+  const savedRef = useRef<AccountProps>({});
+  // Set once the host sends a payload with a recordId.
   const seededRef = useRef(false);
   // Prevents rapid Save re-clicks from firing duplicate updateRecords.
   // The button stays clickable so its state doesn't dirty → clean → dirty
@@ -74,11 +76,23 @@ export default function UnsavedChanges() {
       const ui = sdk.getUiState?.();
       if (!ui) return;
       const seed = (p: AccountProps) => {
+        // Adopt the host's values into the form when the user has nothing in
+        // progress: the first payload, a form still matching the last saved
+        // values, or the echo from our own save (the host may normalize what it
+        // stored). If the user has unsaved edits, keep them.
+        const prevSaved = savedRef.current;
+        const wasSeeded = seededRef.current;
+        const wasSaving = savingRef.current;
+        savedRef.current = p;
+        if (p.recordId) seededRef.current = true;
         setSaved(p);
-        if (!seededRef.current && p.recordId) {
-          setForm(p);
-          seededRef.current = true;
-        }
+        setForm(prevForm => {
+          const pristine =
+            prevForm.name === prevSaved.name &&
+            prevForm.rating === prevSaved.rating &&
+            prevForm.type === prevSaved.type;
+          return !wasSeeded || pristine || wasSaving ? p : prevForm;
+        });
       };
       seed(ui.state.props as AccountProps);
       unsubscribe = ui.subscribe(latest => {
@@ -123,7 +137,7 @@ export default function UnsavedChanges() {
       new CustomEvent('guestsave', {
         detail: { name: form.name, rating: form.rating, type: form.type },
         bubbles: true,
-      }),
+      })
     );
     // The host normally releases the guard by echoing fresh values via
     // ui-state. If its updateRecord fails (it surfaces a toast and doesn't


### PR DESCRIPTION
### What does this PR do?

Fixes the phantom dirty state in the **Unsaved Changes** embedding guest (#81), in both React and Angular.

The guest seeded its editable form from `ui-state` only on the *first* payload with a `recordId`. After that, `saved` kept updating from host echoes while `form` stayed frozen — so a background host update (e.g. another component editing the same Account, or LDS re-emitting) made `saved` diverge from an untouched `form`, flipped `isDirty` true, and showed a Save/Discard bar the user never triggered.

Now the form **adopts** the host's values whenever the user has nothing in progress:
- the first payload,
- a pristine form (still equal to the last saved values), or
- the echo from the guest's own save (the host may normalize what it stored).

Genuine in-progress edits are preserved.

- **React:** `UnsavedChanges.tsx` — uses a `savedRef` to compare against the last saved values synchronously inside the ui-state subscription (its captured state is stale).
- **Angular:** `unsaved-changes.ts` — reads the `isDirty` signal directly.

### Testing

Added regression tests to both guests: an untouched form adopts a later host update, and an edited form keeps its in-progress changes. React (vitest) + `tsc` + eslint + prettier clean; Angular `ng lint` + build + tests green.

Closes #81
