### PR TITLE
fix(recipes): drop out-of-order query responses in debounced/refetch recipes

### DIFF
--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.html
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.html
@@ -17,7 +17,7 @@
 		<p class="text-destructive mt-2">{{ error }}</p>
 	} @else if (search().trim() && contacts().length === 0) {
 		<p class="text-muted-foreground mt-2">No contacts found.</p>
-	} @else if (contacts().length > 0) {
+	} @else if (search().trim() && contacts().length > 0) {
 		<div class="rounded-md border border-border bg-card p-4 shadow-sm">
 			<ul class="divide-y">
 				@for (contact of contacts(); track contact.id) {

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.spec.ts
@@ -10,6 +10,30 @@ vi.mock('@salesforce/platform-sdk', () => ({
 
 const mockQuery = vi.fn();
 
+function contactResult(name: string) {
+	return {
+		data: {
+			uiapi: {
+				query: {
+					Contact: {
+						edges: [
+							{
+								node: {
+									Id: name,
+									Name: { value: name },
+									Title: { value: null },
+									Phone: { value: null },
+									Picture__c: { value: null },
+								},
+							},
+						],
+					},
+				},
+			},
+		},
+	};
+}
+
 describe('FilteredListComponent', () => {
 	beforeEach(() => {
 		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
@@ -47,5 +71,33 @@ describe('FilteredListComponent', () => {
 
 		expect(mockQuery).toHaveBeenCalledWith(expect.objectContaining({ variables: { name: '%Amy%' } }));
 		expect(fixture.nativeElement.textContent).toContain('Amy Taylor');
+	});
+
+	it('ignores a stale response that resolves after a newer one', async () => {
+		const resolvers: ((value: unknown) => void)[] = [];
+		mockQuery.mockImplementation(() => new Promise((resolve) => resolvers.push(resolve)));
+
+		await TestBed.configureTestingModule({ imports: [FilteredListComponent] }).compileComponents();
+		const fixture = TestBed.createComponent(FilteredListComponent);
+		fixture.detectChanges();
+		const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+		input.value = 'a';
+		input.dispatchEvent(new Event('input'));
+		await new Promise((resolve) => setTimeout(resolve, 350));
+		input.value = 'ab';
+		input.dispatchEvent(new Event('input'));
+		await new Promise((resolve) => setTimeout(resolve, 350));
+
+		expect(resolvers).toHaveLength(2);
+		resolvers[1](contactResult('Newer Match'));
+		resolvers[0](contactResult('Stale Match'));
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+
+		const text = fixture.nativeElement.textContent;
+		expect(text).toContain('Newer Match');
+		expect(text).not.toContain('Stale Match');
 	});
 });

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.spec.ts
@@ -39,7 +39,10 @@ describe('FilteredListComponent', () => {
 		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
 	});
 
-	afterEach(() => vi.clearAllMocks());
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+	});
 
 	it('queries with a wildcard variable and renders matches after debounce', async () => {
 		mockQuery.mockResolvedValue({
@@ -74,6 +77,7 @@ describe('FilteredListComponent', () => {
 	});
 
 	it('ignores a stale response that resolves after a newer one', async () => {
+		vi.useFakeTimers();
 		const resolvers: ((value: unknown) => void)[] = [];
 		mockQuery.mockImplementation(() => new Promise((resolve) => resolvers.push(resolve)));
 
@@ -84,16 +88,15 @@ describe('FilteredListComponent', () => {
 
 		input.value = 'a';
 		input.dispatchEvent(new Event('input'));
-		await new Promise((resolve) => setTimeout(resolve, 350));
+		await vi.advanceTimersByTimeAsync(300);
 		input.value = 'ab';
 		input.dispatchEvent(new Event('input'));
-		await new Promise((resolve) => setTimeout(resolve, 350));
+		await vi.advanceTimersByTimeAsync(300);
 
 		expect(resolvers).toHaveLength(2);
 		resolvers[1](contactResult('Newer Match'));
 		resolvers[0](contactResult('Stale Match'));
-		await fixture.whenStable();
-		await new Promise((resolve) => setTimeout(resolve));
+		await vi.advanceTimersByTimeAsync(0);
 		fixture.detectChanges();
 
 		const text = fixture.nativeElement.textContent;

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/filtered-list/filtered-list.ts
@@ -54,9 +54,10 @@ export class FilteredListComponent implements OnDestroy {
 	protected readonly error = signal<string | undefined>(undefined);
 
 	private timer?: ReturnType<typeof setTimeout>;
+	private requestId = 0;
 
-	// Debounce: wait 300ms after the last keystroke before querying. Clearing the
-	// pending timer on each keystroke cancels the previous, in-flight request.
+	// Debounce: wait 300ms after the last keystroke before querying, so a burst
+	// of typing fires one request instead of one per character.
 	protected onSearch(value: string): void {
 		this.search.set(value);
 		clearTimeout(this.timer);
@@ -73,6 +74,7 @@ export class FilteredListComponent implements OnDestroy {
 	}
 
 	private async fetch(term: string): Promise<void> {
+		const id = ++this.requestId;
 		this.loading.set(true);
 		try {
 			const sdk = await createDataSDK();
@@ -80,6 +82,8 @@ export class FilteredListComponent implements OnDestroy {
 				query: QUERY,
 				variables: { name: `%${term}%` },
 			});
+
+			if (id !== this.requestId) return;
 
 			if (result?.errors?.length) {
 				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
@@ -99,9 +103,10 @@ export class FilteredListComponent implements OnDestroy {
 					})),
 			);
 		} catch (err) {
+			if (id !== this.requestId) return;
 			this.error.set(err instanceof Error ? err.message : 'Request failed');
 		} finally {
-			this.loading.set(false);
+			if (id === this.requestId) this.loading.set(false);
 		}
 	}
 }

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/read-data/sorted-results/sorted-results.ts
@@ -61,6 +61,8 @@ export class SortedResultsComponent implements OnInit {
 	protected readonly loading = signal(true);
 	protected readonly error = signal<string | undefined>(undefined);
 
+	private requestId = 0;
+
 	ngOnInit(): void {
 		this.load();
 	}
@@ -80,6 +82,7 @@ export class SortedResultsComponent implements OnInit {
 	}
 
 	private async load(): Promise<void> {
+		const id = ++this.requestId;
 		this.loading.set(true);
 		this.error.set(undefined);
 		try {
@@ -87,6 +90,8 @@ export class SortedResultsComponent implements OnInit {
 			const result = await sdk.graphql?.query<SortedContactsResponse>({
 				query: buildQuery(this.field(), this.dir()),
 			});
+
+			if (id !== this.requestId) return;
 
 			if (result?.errors?.length) {
 				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
@@ -104,9 +109,10 @@ export class SortedResultsComponent implements OnInit {
 					})),
 			);
 		} catch (err) {
+			if (id !== this.requestId) return;
 			this.error.set(err instanceof Error ? err.message : 'Request failed');
 		} finally {
-			this.loading.set(false);
+			if (id === this.requestId) this.loading.set(false);
 		}
 	}
 }

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/routing/route-parameters-detail/route-parameters-detail.spec.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/routing/route-parameters-detail/route-parameters-detail.spec.ts
@@ -11,6 +11,30 @@ vi.mock('@salesforce/platform-sdk', () => ({
 
 const mockQuery = vi.fn();
 
+function accountResult(name: string) {
+	return {
+		data: {
+			uiapi: {
+				query: {
+					Account: {
+						edges: [
+							{
+								node: {
+									Id: name,
+									Name: { value: name },
+									Industry: { value: null },
+									Phone: { value: null },
+									Website: { value: null },
+								},
+							},
+						],
+					},
+				},
+			},
+		},
+	};
+}
+
 describe('RouteParametersDetailComponent', () => {
 	beforeEach(() => {
 		(createDataSDK as Mock).mockResolvedValue({ graphql: { query: mockQuery } });
@@ -34,5 +58,32 @@ describe('RouteParametersDetailComponent', () => {
 		expect(mockQuery.mock.calls[0][0].variables).toEqual({ id: '001X' });
 		expect(fixture.nativeElement.textContent).toContain('Edge Communications');
 		expect(fixture.nativeElement.textContent).toContain('Electronics');
+	});
+
+	it('ignores a stale detail response that resolves after a newer one', async () => {
+		const resolvers: ((value: unknown) => void)[] = [];
+		mockQuery.mockImplementation(() => new Promise((resolve) => resolvers.push(resolve)));
+
+		await TestBed.configureTestingModule({
+			imports: [RouteParametersDetailComponent],
+			providers: [provideRouter([])],
+		}).compileComponents();
+		const fixture = TestBed.createComponent(RouteParametersDetailComponent);
+
+		fixture.componentRef.setInput('accountId', '001A');
+		await fixture.whenStable();
+		fixture.componentRef.setInput('accountId', '001B');
+		await fixture.whenStable();
+
+		expect(resolvers).toHaveLength(2);
+		resolvers[1](accountResult('Newer Account'));
+		resolvers[0](accountResult('Stale Account'));
+		await fixture.whenStable();
+		await new Promise((resolve) => setTimeout(resolve));
+		fixture.detectChanges();
+
+		const text = fixture.nativeElement.textContent;
+		expect(text).toContain('Newer Account');
+		expect(text).not.toContain('Stale Account');
 	});
 });

--- a/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/routing/route-parameters-detail/route-parameters-detail.ts
+++ b/force-app/main/angular-recipes/uiBundles/angularRecipes/src/app/recipes/routing/route-parameters-detail/route-parameters-detail.ts
@@ -51,6 +51,8 @@ export class RouteParametersDetailComponent {
 	protected readonly loading = signal(true);
 	protected readonly error = signal<string | undefined>(undefined);
 
+	private requestId = 0;
+
 	constructor() {
 		effect(() => {
 			const id = this.accountId();
@@ -59,6 +61,7 @@ export class RouteParametersDetailComponent {
 	}
 
 	private async load(id: string): Promise<void> {
+		const reqId = ++this.requestId;
 		this.loading.set(true);
 		this.error.set(undefined);
 		try {
@@ -67,6 +70,9 @@ export class RouteParametersDetailComponent {
 				query: DETAIL_QUERY,
 				variables: { id },
 			});
+
+			if (reqId !== this.requestId) return;
+
 			if (result?.errors?.length) {
 				throw new Error(result.errors.map((e: { message: string }) => e.message).join('; '));
 			}
@@ -82,9 +88,10 @@ export class RouteParametersDetailComponent {
 					: undefined,
 			);
 		} catch (err) {
+			if (reqId !== this.requestId) return;
 			this.error.set(err instanceof Error ? err.message : 'Request failed');
 		} finally {
-			this.loading.set(false);
+			if (reqId === this.requestId) this.loading.set(false);
 		}
 	}
 }

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/integration/SearchableAccountList.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/integration/SearchableAccountList.tsx
@@ -77,8 +77,10 @@ export default function SearchableAccountList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const requestIdRef = useRef(0);
 
   const fetchAccounts = useCallback(async (term: string) => {
+    const id = ++requestIdRef.current;
     setLoading(true);
     setError(undefined);
 
@@ -89,6 +91,8 @@ export default function SearchableAccountList() {
         query: QUERY,
         variables: { name: term ? `%${term}%` : '%%' },
       });
+
+      if (id !== requestIdRef.current) return;
 
       if (result?.errors?.length) {
         throw new Error(
@@ -108,9 +112,10 @@ export default function SearchableAccountList() {
           }))
       );
     } catch (err) {
+      if (id !== requestIdRef.current) return;
       setError(err instanceof Error ? err.message : 'Request failed');
     } finally {
-      setLoading(false);
+      if (id === requestIdRef.current) setLoading(false);
     }
   }, []);
 

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/read-data/FilteredList.test.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/read-data/FilteredList.test.tsx
@@ -38,6 +38,31 @@ const FILTERED_SUCCESS = {
   errors: [],
 };
 
+function contactResult(name: string) {
+  return {
+    data: {
+      uiapi: {
+        query: {
+          Contact: {
+            edges: [
+              {
+                node: {
+                  Id: name,
+                  Name: { value: name },
+                  Title: { value: null },
+                  Phone: { value: null },
+                  Picture__c: { value: null },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [],
+  };
+}
+
 describe('FilteredList', () => {
   const mockGraphql = vi.fn();
 
@@ -112,6 +137,33 @@ describe('FilteredList', () => {
       query: expect.any(String),
       variables: { name: '%Alice%' },
     });
+  });
+
+  it('ignores a stale response that resolves after a newer one', async () => {
+    const resolvers: Array<(value: unknown) => void> = [];
+    mockGraphql.mockImplementation(
+      () => new Promise(resolve => resolvers.push(resolve))
+    );
+    render(<FilteredList />);
+    const input = screen.getByPlaceholderText('Search by name…');
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+    fireEvent.change(input, { target: { value: 'ab' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    expect(resolvers).toHaveLength(2);
+    await act(async () => {
+      resolvers[1](contactResult('Newer Match'));
+      resolvers[0](contactResult('Stale Match'));
+    });
+
+    expect(screen.getByText('Newer Match')).toBeInTheDocument();
+    expect(screen.queryByText('Stale Match')).toBeNull();
   });
 
   it('is accessible', async () => {

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/read-data/FilteredList.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/read-data/FilteredList.tsx
@@ -11,7 +11,7 @@
  * @see SortedResults — sorting query results with dynamic orderBy
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createDataSDK, gql } from '@salesforce/platform-sdk';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Input } from '@/components/ui/input';
@@ -81,6 +81,7 @@ export default function FilteredList() {
   const [contacts, setContacts] = useState<ContactFields[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
     if (!search.trim()) return;
@@ -91,6 +92,7 @@ export default function FilteredList() {
     // The cleanup cancels the pending timer if search changes again before it fires.
     const timer = setTimeout(() => {
       setLoading(true);
+      const id = ++requestIdRef.current;
       const fetchFiltered = async () => {
         const sdk = await createDataSDK();
         // Wrap the search term in % wildcards for the `like` operator
@@ -98,6 +100,8 @@ export default function FilteredList() {
           query: QUERY,
           variables: { name: `%${search}%` },
         });
+
+        if (id !== requestIdRef.current) return;
 
         if (result?.errors?.length) {
           throw new Error(
@@ -122,9 +126,12 @@ export default function FilteredList() {
 
       fetchFiltered()
         .catch(err => {
+          if (id !== requestIdRef.current) return;
           setError(err instanceof Error ? err.message : 'Request failed');
         })
-        .finally(() => setLoading(false));
+        .finally(() => {
+          if (id === requestIdRef.current) setLoading(false);
+        });
     }, 300);
 
     return () => clearTimeout(timer);

--- a/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/read-data/SortedResults.tsx
+++ b/force-app/main/react-recipes/uiBundles/reactRecipes/src/recipes/read-data/SortedResults.tsx
@@ -12,7 +12,7 @@
  * @see PaginatedList — cursor-based pagination with Load More
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createDataSDK } from '@salesforce/platform-sdk';
 
 type SortField = 'Name' | 'Title' | 'Phone';
@@ -78,18 +78,22 @@ export default function SortedResults() {
   const [contacts, setContacts] = useState<ContactFields[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
+  const requestIdRef = useRef(0);
 
   // Re-fetch whenever sort field or direction changes
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     setError(undefined);
+    const id = ++requestIdRef.current;
 
     const fetchSorted = async () => {
       const sdk = await createDataSDK();
       const result = await sdk.graphql?.query<SortedContactsResponse>({
         query: buildQuery(field, dir),
       });
+
+      if (id !== requestIdRef.current) return;
 
       if (result?.errors?.length) {
         throw new Error(
@@ -112,9 +116,12 @@ export default function SortedResults() {
 
     fetchSorted()
       .catch(err => {
+        if (id !== requestIdRef.current) return;
         setError(err instanceof Error ? err.message : 'Request failed');
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (id === requestIdRef.current) setLoading(false);
+      });
   }, [field, dir]);
 
   return (


### PR DESCRIPTION
### What does this PR do?

Fixes out-of-order response handling in the debounced / re-fetch recipes (#82), in both React and Angular.

Debouncing with `clearTimeout` only cancels a timer that hasn't fired yet — it can't cancel a query that's already been dispatched and is awaiting the network. Without a request-sequence guard, an earlier (slower) response can resolve after a newer one and overwrite it, showing results for the wrong query.

Each affected component now tracks a monotonic request id, captures it when a query starts, and discards the response (and its loading/error updates) if a newer request has started since.

**Files (React + Angular):**
- `read-data` → Filtered List, Sorted Results
- `routing` → Route Parameters (detail)
- `integration` → Searchable Account List *(React only — Angular's already had this guard, which is the pattern applied here)*

### Testing

Added an out-of-order regression test for the debounced Filtered List in both frameworks (two searches in flight; the older resolves last and must be dropped). React (vitest) + `tsc` + eslint clean; Angular `ng lint` + build + tests green. Existing tests for the other recipes continue to pass.

Closes #82
